### PR TITLE
Update 0.8.2: ASR ciąg dalszy i różne poprawki

### DIFF
--- a/app/src/main/java/me/proteus/myeye/SerializableStage.java
+++ b/app/src/main/java/me/proteus/myeye/SerializableStage.java
@@ -2,13 +2,15 @@ package me.proteus.myeye;
 
 import java.io.Serializable;
 
-public class SerializablePair implements Serializable {
+public class SerializableStage implements Serializable {
     private final String first;
     private final String second;
+    private final int difficulty;
 
-    public SerializablePair(String first, String second) {
+    public SerializableStage(String first, String second, int difficulty) {
         this.first = first;
         this.second = second;
+        this.difficulty = difficulty;
     }
 
     public String getFirst() {
@@ -19,4 +21,7 @@ public class SerializablePair implements Serializable {
         return second;
     }
 
+    public int getDifficulty() {
+        return difficulty;
+    }
 }

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -59,7 +59,11 @@ interface VisionTest {
                     if (i > 0) i--
                 } else if (answer == "NEXT") {
                     if (i < stageList.size - 1) i++
-                    // else powrot do menu
+                    else {
+                        var exitIntent = Intent(activity, MenuActivity::class.java)
+                        // TODO: Dodac podsumowanie testu
+                        activity.startActivity(exitIntent)
+                    }
                 }
             }
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import me.proteus.myeye.io.ResultDataCollector
@@ -53,14 +54,25 @@ interface VisionTest {
         }
 
         var stageIterator by remember { mutableIntStateOf(0) }
-        var currentStage: SerializablePair = stageList[stageIterator]
+        var currentStage by remember { mutableStateOf(stageList[stageIterator]) }
 
         DisplayStage(activity, currentStage, isResult) { answer ->
 
-            println("Answer: $answer")
-            storeResult(currentStage.first, answer)
-            stageIterator++
-            println(stageIterator)
+            if (answer == "REGENERATE") {
+
+                currentStage = SerializablePair(
+                    generateQuestion().toString(),
+                    getExampleAnswers().joinToString(" ")
+                )
+                println("Regenerate")
+
+            } else {
+                println("Answer: $answer")
+                storeResult(currentStage.first, answer)
+                stageIterator++
+                println(stageIterator)
+            }
+
 
         }
 
@@ -75,7 +87,6 @@ interface VisionTest {
     fun storeResult(question: String, answer: String) {
         resultCollector.addResult(question, answer)
     }
-
 
      fun endTest(activity: VisionTestLayoutActivity) {
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -25,10 +25,10 @@ interface VisionTest {
      * @param activity The canvas activity to display the layout
      */
     @Composable
-    fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean)
+    fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean)
 
     @Composable
-    fun BeginTest(activity: VisionTestLayoutActivity, modifier: Modifier, isResult: Boolean, result: TestResult?) {
+    fun BeginTest(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?) {
 
         var stageList: MutableList<SerializablePair> = ArrayList<SerializablePair>()
 
@@ -45,7 +45,7 @@ interface VisionTest {
             }
         }
 
-        DisplayStage(activity, modifier, stageList, false)
+        DisplayStage(activity, stageList, false)
 
     }
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -49,7 +49,7 @@ interface VisionTest {
 
     }
 
-    fun generateQuestion(): Any
+    fun generateQuestion(): String
 
     fun getExampleAnswers(): Array<String>
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -34,6 +34,8 @@ interface VisionTest {
     @Composable
     fun BeginTest(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?) {
 
+        var stageIterator by remember { mutableIntStateOf(0) }
+
         var stageList = remember {
             mutableListOf<SerializablePair>().apply {
                 if (isResult) {
@@ -44,16 +46,17 @@ interface VisionTest {
                 } else {
                     for (i in 0..<stageCount) {
                         var pair = SerializablePair(
-                            generateQuestion().toString(),
+                            generateQuestion(stageIterator).toString(),
                             getExampleAnswers().joinToString(" ")
                         )
                         add(pair)
+                        stageIterator++
                     }
                 }
             }
         }
 
-        var stageIterator by remember { mutableIntStateOf(0) }
+        stageIterator = 0
         var currentStage by remember { mutableStateOf(stageList[stageIterator]) }
 
         DisplayStage(activity, currentStage, isResult) { answer ->
@@ -61,7 +64,7 @@ interface VisionTest {
             if (answer == "REGENERATE") {
 
                 currentStage = SerializablePair(
-                    generateQuestion().toString(),
+                    generateQuestion(stageIterator).toString(),
                     getExampleAnswers().joinToString(" ")
                 )
                 println("Regenerate")
@@ -78,7 +81,7 @@ interface VisionTest {
 
     }
 
-    fun generateQuestion(): String
+    fun generateQuestion(stage: Int?): String
 
     fun getExampleAnswers(): Array<String>
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -39,6 +39,11 @@ interface VisionTest {
 
     @Composable
     fun BeginTest(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?) {
+        BeginTestImpl(activity, isResult, result)
+    }
+
+    @Composable
+    fun BeginTestImpl(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?) {
 
         if (isResult) {
             var i by remember { mutableIntStateOf(0) }

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -59,7 +59,7 @@ interface VisionTest {
 
         } else {
 
-            var currentDifficulty by remember { mutableIntStateOf(1) }
+            var currentDifficulty by remember { mutableIntStateOf(0) }
 
             var currentStage = SerializableStage(
                 generateQuestion(currentDifficulty).toString(),

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.graphics.vector.ImageVector
 import me.proteus.myeye.io.ResultDataCollector
@@ -61,11 +62,13 @@ interface VisionTest {
 
             var currentDifficulty by remember { mutableIntStateOf(0) }
 
-            var currentStage = SerializableStage(
-                generateQuestion(currentDifficulty).toString(),
-                getExampleAnswers().joinToString(" "),
-                currentDifficulty
-            )
+            var currentStage by remember { mutableStateOf(
+                SerializableStage(
+                    generateQuestion(currentDifficulty).toString(),
+                    getExampleAnswers().joinToString(" "),
+                    currentDifficulty
+                )
+            ) }
 
             DisplayStage(activity, currentStage, false, currentDifficulty) { answer ->
 
@@ -88,7 +91,6 @@ interface VisionTest {
                     storeResult(currentStage.first, answer, currentDifficulty)
                     currentDifficulty++
                 }
-
 
             }
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -45,7 +45,7 @@ interface VisionTest {
             }
         }
 
-        DisplayStage(activity, stageList, false)
+        DisplayStage(activity, stageList, isResult)
 
     }
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -28,7 +28,26 @@ interface VisionTest {
     fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean)
 
     @Composable
-    fun BeginTest(activity: VisionTestLayoutActivity, modifier: Modifier, isResult: Boolean, result: TestResult?)
+    fun BeginTest(activity: VisionTestLayoutActivity, modifier: Modifier, isResult: Boolean, result: TestResult?) {
+
+        var stageList: MutableList<SerializablePair> = ArrayList<SerializablePair>()
+
+        if (isResult) {
+            val resultData = ResultDataCollector.deserializeResult(result!!.result)
+            for (i in 0..<resultData.size) {
+                stageList.add(resultData[i])
+            }
+        } else {
+            for (i in 0..<stageCount) {
+                var pair = SerializablePair(this.generateQuestion().toString(), this.getExampleAnswers().joinToString(" "))
+                println(pair.first + " " + pair.second)
+                stageList.add(pair)
+            }
+        }
+
+        DisplayStage(activity, modifier, stageList, false)
+
+    }
 
     fun generateQuestion(): Any
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -104,24 +104,6 @@ interface VisionTest {
             }
 
         }
-//
-//        var stageList = remember {
-//            mutableListOf<SerializablePair>().apply {
-//                if (isResult) {
-//
-//                } else {
-//                    for (i in 0..<stageCount) {
-//                        var pair = SerializablePair(
-//                            generateQuestion(stageIterator).toString(),
-//                            getExampleAnswers().joinToString(" ")
-//                        )
-//                        add(pair)
-//                        stageIterator++
-//                    }
-//                }
-//            }
-//        }
-
 
     }
 

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -1,4 +1,4 @@
-package me.proteus.myeye.ui
+package me.proteus.myeye.io
 
 import android.annotation.SuppressLint
 import android.app.Application
@@ -6,21 +6,16 @@ import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
-import androidx.lifecycle.ViewModel
-import me.proteus.myeye.io.FileSaver
-import me.proteus.myeye.io.HTTPDownloader
-import me.proteus.myeye.io.SpeechDecoderResult
 import org.vosk.Model
 import org.vosk.Recognizer
 import java.io.File
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 
-class SpeechDecoderViewModel(application: Application) : AndroidViewModel(application) {
+class ASRViewModel(application: Application) : AndroidViewModel(application) {
 
     private lateinit var recognizer: Recognizer
     private lateinit var model: Model
@@ -144,7 +139,6 @@ class SpeechDecoderViewModel(application: Application) : AndroidViewModel(applic
 
         }
     }
-
 
      fun startRecognition(onResult: (String) -> Unit) {
         executor.execute {

--- a/app/src/main/java/me/proteus/myeye/io/FileSaver.java
+++ b/app/src/main/java/me/proteus/myeye/io/FileSaver.java
@@ -16,7 +16,7 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.regex.*;
 
-import me.proteus.myeye.SerializablePair;
+import me.proteus.myeye.SerializableStage;
 
 public class FileSaver {
 
@@ -148,7 +148,7 @@ public class FileSaver {
 
         for (int i=0;i<data.stages.size();i++) {
 
-            SerializablePair p = data.stages.get(i);
+            SerializableStage p = data.stages.get(i);
 
             fw.write(System.lineSeparator());
             fw.write(i + " " + p.getFirst() + " " + p.getSecond());

--- a/app/src/main/java/me/proteus/myeye/io/ResultDataCollector.java
+++ b/app/src/main/java/me/proteus/myeye/io/ResultDataCollector.java
@@ -25,6 +25,12 @@ public class ResultDataCollector {
 
     }
 
+    public void addResult(SerializablePair p) {
+
+        stages.add(p);
+
+    }
+
 
     public static byte[] serializeResult(List<SerializablePair> input) {
 

--- a/app/src/main/java/me/proteus/myeye/io/ResultDataCollector.java
+++ b/app/src/main/java/me/proteus/myeye/io/ResultDataCollector.java
@@ -8,31 +8,31 @@ import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
-import me.proteus.myeye.SerializablePair;
+import me.proteus.myeye.SerializableStage;
 
 public class ResultDataCollector {
-    public final List<SerializablePair> stages = new ArrayList<>();
+    public final List<SerializableStage> stages = new ArrayList<>();
 
 
     public ResultDataCollector() {
 
     }
 
-    public void addResult(String q, String a) {
+    public void addResult(String q, String a, int d) {
 
-        SerializablePair p = new SerializablePair(q, a);
+        SerializableStage p = new SerializableStage(q, a, d);
         stages.add(p);
 
     }
 
-    public void addResult(SerializablePair p) {
+    public void addResult(SerializableStage p) {
 
         stages.add(p);
 
     }
 
 
-    public static byte[] serializeResult(List<SerializablePair> input) {
+    public static byte[] serializeResult(List<SerializableStage> input) {
 
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         ObjectOutputStream oos;
@@ -53,7 +53,7 @@ public class ResultDataCollector {
 
     }
 
-    public static List<SerializablePair> deserializeResult(byte[] object) {
+    public static List<SerializableStage> deserializeResult(byte[] object) {
 
         ByteArrayInputStream bais = new ByteArrayInputStream(object);
 
@@ -61,7 +61,7 @@ public class ResultDataCollector {
 
             ObjectInputStream ois = new ObjectInputStream(bais);
             @SuppressWarnings("unchecked")
-            List<SerializablePair> output = (List<SerializablePair>) ois.readObject();
+            List<SerializableStage> output = (List<SerializableStage>) ois.readObject();
             ois.close();
 
             return output;

--- a/app/src/main/java/me/proteus/myeye/io/ResultDataSaver.java
+++ b/app/src/main/java/me/proteus/myeye/io/ResultDataSaver.java
@@ -12,7 +12,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import me.proteus.myeye.SerializablePair;
+import me.proteus.myeye.SerializableStage;
 import me.proteus.myeye.TestResult;
 
 public class ResultDataSaver {
@@ -121,7 +121,7 @@ public class ResultDataSaver {
         return null;
     }
 
-    public void insert(String testName, List<SerializablePair> result, long ts) {
+    public void insert(String testName, List<SerializableStage> result, long ts) {
 
         SupportSQLiteDatabase db = this.dbHelper.getWritableDatabase();
 

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -17,10 +17,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
+import me.proteus.myeye.io.ASRViewModel
 
 class SpeechDecoderActivity : ComponentActivity() {
 
-    private val viewModel: SpeechDecoderViewModel by viewModels()
+    private val viewModel: ASRViewModel by viewModels()
 
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -1,13 +1,8 @@
 package me.proteus.myeye.ui
 
 import android.Manifest
-import android.annotation.SuppressLint
 import android.content.pm.PackageManager
-import android.media.AudioFormat
-import android.media.AudioRecord
-import android.media.MediaRecorder
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -22,31 +17,11 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
-import me.proteus.myeye.io.FileSaver
-import me.proteus.myeye.io.HTTPDownloader
-import me.proteus.myeye.io.SpeechDecoderResult
-import org.vosk.Model
-import org.vosk.Recognizer
-import java.io.File
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.Executors
-import kotlin.collections.plus
 
 class SpeechDecoderActivity : ComponentActivity() {
 
-    private lateinit var recognizer: Recognizer
-    private lateinit var model: Model
-    private lateinit var audioRecord: AudioRecord
-    private var executor: ExecutorService = Executors.newSingleThreadExecutor()
-    private var modelName: String = "vosk-model-small-pl-0.22"
-
     private val viewModel: SpeechDecoderViewModel by viewModels()
 
-    val modelGrammar = listOf<String>("a", "a", "a", "a", "be", "ce", "de", "e", "f",
-        "gdzie", "ha", "i", "jod", "ka", "el", "m", "n", "o", "p", "q", "r", "er",
-        "es", "te", "u", "wał", "wu", "ix", "igrek", "zet",
-        "jeden", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "zero"
-    )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -54,7 +29,7 @@ class SpeechDecoderActivity : ComponentActivity() {
         val requestPermissionLauncher =
             registerForActivityResult(ActivityResultContracts.RequestPermission()) { isGranted: Boolean ->
                 if (isGranted) {
-                    initializeVosk()
+                    viewModel.initialize()
                 } else {
                     println("Brak uprawnien")
                 }
@@ -62,7 +37,7 @@ class SpeechDecoderActivity : ComponentActivity() {
 
 
         if (checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-            initializeVosk()
+            viewModel.initialize()
         } else {
             requestPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
         }
@@ -113,129 +88,9 @@ class SpeechDecoderActivity : ComponentActivity() {
 
     }
 
-    @SuppressLint("MissingPermission")
-    fun getMaximumSampleRate(): Int {
-
-        val all = listOf(48000, 44100, 22050, 16000, 11025, 8000)
-
-        for (rate in all) {
-            val bufsize = AudioRecord.getMinBufferSize(
-                rate,
-                AudioFormat.CHANNEL_IN_MONO,
-                AudioFormat.ENCODING_PCM_16BIT
-            )
-
-            if (bufsize != AudioRecord.ERROR && bufsize != AudioRecord.ERROR_BAD_VALUE) {
-                val audioRecord = AudioRecord(
-                    MediaRecorder.AudioSource.MIC,
-                    rate,
-                    AudioFormat.CHANNEL_IN_MONO,
-                    AudioFormat.ENCODING_PCM_16BIT,
-                    bufsize
-                )
-
-                if (audioRecord.state == AudioRecord.STATE_INITIALIZED) {
-                    audioRecord.release()
-                    return rate
-                }
-
-                audioRecord.release()
-            }
-        }
-
-        return 0
-
-    }
-
-    @SuppressLint("MissingPermission")
-    private fun initializeVosk() {
-        executor.execute {
-
-            val samplerate = getMaximumSampleRate()
-            println(samplerate)
-
-            val bufferSize = AudioRecord.getMinBufferSize(
-                samplerate,
-                AudioFormat.CHANNEL_IN_MONO,
-                AudioFormat.ENCODING_PCM_16BIT
-            )
-
-            audioRecord = AudioRecord(
-                MediaRecorder.AudioSource.MIC,
-                samplerate,
-                AudioFormat.CHANNEL_IN_MONO,
-                AudioFormat.ENCODING_PCM_16BIT,
-                bufferSize
-            )
-
-            var modelDir: File = File(this.filesDir.path + "/models/" + modelName)
-
-            if (!modelDir.exists()) {
-
-                var rootUrl = "https://alphacephei.com/vosk/models/"
-                var downloaderPromise = HTTPDownloader().download(
-                    "$rootUrl$modelName.zip",
-                    File(modelDir.path + ".zip")
-                )
-
-                downloaderPromise.thenRun {
-                    FileSaver.unzip(File(modelDir.path + ".zip"))
-                    model = Model(modelDir.path)
-
-                    initRecognizer(samplerate)
-
-                } .exceptionally { e ->
-                    println("Error: $e")
-                    return@exceptionally null
-                }
-
-            } else {
-                model = Model(modelDir.path)
-                initRecognizer(samplerate)
-            }
-        }
-    }
-
-    fun initRecognizer(samplerate: Int) {
-
-        recognizer = Recognizer(model, samplerate.toFloat()).apply {
-            setWords(true)
-            setPartialWords(true)
-            setGrammar("[\"" + modelGrammar.joinToString(
-                separator = "\",\"",
-            ) + "\"]")
-        }
-
-        startRecognition { newResult ->
-            val words = SpeechDecoderResult.deserialize(newResult)
-            for (el in words) {
-                viewModel.addWord(el)
-            }
-
-        }
-    }
-
-
-    private fun startRecognition(onResult: (String) -> Unit) {
-        executor.execute {
-            audioRecord.startRecording()
-            val buffer = ByteArray(4096)
-
-            while (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
-                val bytesRead = audioRecord.read(buffer, 0, buffer.size)
-                if (bytesRead > 0) {
-                    if (recognizer.acceptWaveForm(buffer, bytesRead)) {
-                        onResult(recognizer.result)
-                    }
-                }
-            }
-        }
-    }
 
     override fun onDestroy() {
         super.onDestroy()
-        audioRecord.stop()
-        audioRecord.release()
-        executor.shutdown()
+        viewModel.close()
     }
 }

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
@@ -1,0 +1,20 @@
+package me.proteus.myeye.ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+import me.proteus.myeye.io.SpeechDecoderResult
+
+class SpeechDecoderViewModel : ViewModel() {
+
+    var result: List<SpeechDecoderResult> by mutableStateOf(listOf())
+
+    fun addWord(word: SpeechDecoderResult) {
+        result.toMutableList().apply {
+            add(word)
+        }
+    }
+
+}

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
@@ -12,9 +12,7 @@ class SpeechDecoderViewModel : ViewModel() {
     var result: List<SpeechDecoderResult> by mutableStateOf(listOf())
 
     fun addWord(word: SpeechDecoderResult) {
-        result.toMutableList().apply {
-            add(word)
-        }
+        result = result + word
     }
 
 }

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
@@ -27,7 +27,6 @@ class SpeechDecoderViewModel(application: Application) : AndroidViewModel(applic
     private lateinit var audioRecord: AudioRecord
     private var executor: ExecutorService = Executors.newSingleThreadExecutor()
     private var modelName: String = "vosk-model-small-pl-0.22"
-    private var context = getApplication<Application>().applicationContext
 
     val modelGrammar = listOf<String>("a", "a", "a", "a", "be", "ce", "de", "e", "f",
         "gdzie", "ha", "i", "jod", "ka", "el", "m", "n", "o", "p", "q", "r", "er",
@@ -77,6 +76,9 @@ class SpeechDecoderViewModel(application: Application) : AndroidViewModel(applic
 
     @SuppressLint("MissingPermission")
     fun initialize() {
+
+        val context = getApplication<Application>().applicationContext
+
         executor.execute {
 
             val samplerate = getMaximumSampleRate()

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderViewModel.kt
@@ -1,18 +1,169 @@
 package me.proteus.myeye.ui
 
+import android.annotation.SuppressLint
+import android.app.Application
+import android.media.AudioFormat
+import android.media.AudioRecord
+import android.media.MediaRecorder
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.ViewModel
+import me.proteus.myeye.io.FileSaver
+import me.proteus.myeye.io.HTTPDownloader
 import me.proteus.myeye.io.SpeechDecoderResult
+import org.vosk.Model
+import org.vosk.Recognizer
+import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
 
-class SpeechDecoderViewModel : ViewModel() {
+class SpeechDecoderViewModel(application: Application) : AndroidViewModel(application) {
+
+    private lateinit var recognizer: Recognizer
+    private lateinit var model: Model
+    private lateinit var audioRecord: AudioRecord
+    private var executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private var modelName: String = "vosk-model-small-pl-0.22"
+    private var context = getApplication<Application>().applicationContext
+
+    val modelGrammar = listOf<String>("a", "a", "a", "a", "be", "ce", "de", "e", "f",
+        "gdzie", "ha", "i", "jod", "ka", "el", "m", "n", "o", "p", "q", "r", "er",
+        "es", "te", "u", "wał", "wu", "ix", "igrek", "zet",
+        "jeden", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć", "zero"
+    )
 
     var result: List<SpeechDecoderResult> by mutableStateOf(listOf())
 
     fun addWord(word: SpeechDecoderResult) {
         result = result + word
+    }
+
+    @SuppressLint("MissingPermission")
+    private fun getMaximumSampleRate(): Int {
+
+        val all = listOf(48000, 44100, 22050, 16000, 11025, 8000)
+
+        for (rate in all) {
+            val bufsize = AudioRecord.getMinBufferSize(
+                rate,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT
+            )
+
+            if (bufsize != AudioRecord.ERROR && bufsize != AudioRecord.ERROR_BAD_VALUE) {
+                val audioRecord = AudioRecord(
+                    MediaRecorder.AudioSource.MIC,
+                    rate,
+                    AudioFormat.CHANNEL_IN_MONO,
+                    AudioFormat.ENCODING_PCM_16BIT,
+                    bufsize
+                )
+
+                if (audioRecord.state == AudioRecord.STATE_INITIALIZED) {
+                    audioRecord.release()
+                    return rate
+                }
+
+                audioRecord.release()
+            }
+        }
+
+        return 0
+
+    }
+
+    @SuppressLint("MissingPermission")
+    fun initialize() {
+        executor.execute {
+
+            val samplerate = getMaximumSampleRate()
+            println(samplerate)
+
+            val bufferSize = AudioRecord.getMinBufferSize(
+                samplerate,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT
+            )
+
+            audioRecord = AudioRecord(
+                MediaRecorder.AudioSource.MIC,
+                samplerate,
+                AudioFormat.CHANNEL_IN_MONO,
+                AudioFormat.ENCODING_PCM_16BIT,
+                bufferSize
+            )
+
+            var modelDir: File = File(context.filesDir.path + "/models/" + modelName)
+
+            if (!modelDir.exists()) {
+
+                var rootUrl = "https://alphacephei.com/vosk/models/"
+                var downloaderPromise = HTTPDownloader().download(
+                    "$rootUrl$modelName.zip",
+                    File(modelDir.path + ".zip")
+                )
+
+                downloaderPromise.thenRun {
+                    FileSaver.unzip(File(modelDir.path + ".zip"))
+                    model = Model(modelDir.path)
+
+                    initRecognizer(samplerate)
+
+                } .exceptionally { e ->
+                    println("Error: $e")
+                    return@exceptionally null
+                }
+
+            } else {
+                model = Model(modelDir.path)
+                initRecognizer(samplerate)
+            }
+        }
+    }
+
+    fun initRecognizer(samplerate: Int) {
+
+        recognizer = Recognizer(model, samplerate.toFloat()).apply {
+            setWords(true)
+            setPartialWords(true)
+            setGrammar("[\"" + modelGrammar.joinToString(
+                separator = "\",\"",
+            ) + "\"]")
+        }
+
+        startRecognition { newResult ->
+            val words = SpeechDecoderResult.deserialize(newResult)
+            for (el in words) {
+                addWord(el)
+            }
+
+        }
+    }
+
+
+     fun startRecognition(onResult: (String) -> Unit) {
+        executor.execute {
+            audioRecord.startRecording()
+            val buffer = ByteArray(4096)
+
+            while (audioRecord.recordingState == AudioRecord.RECORDSTATE_RECORDING) {
+                val bytesRead = audioRecord.read(buffer, 0, buffer.size)
+                if (bytesRead > 0) {
+                    if (recognizer.acceptWaveForm(buffer, bytesRead)) {
+                        onResult(recognizer.result)
+                    }
+                }
+            }
+        }
+    }
+
+    fun close() {
+        audioRecord.stop()
+        audioRecord.release()
+        executor.shutdown()
     }
 
 }

--- a/app/src/main/java/me/proteus/myeye/ui/TestResultActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/TestResultActivity.kt
@@ -145,16 +145,22 @@ fun TestResultScreen(
                             modifier = Modifier,
                             onClick = {
 
-                                if (viewModel.isAuthorized) {
-                                    navigate(resultData)
+                                val debug_auth = false
+
+                                if (debug_auth == true) {
+                                    if (viewModel.isAuthorized) {
+                                        navigate(resultData)
+                                    } else {
+                                        authenticateUser(activity,
+                                            onSuccess = {
+                                                viewModel.authenticate()
+                                                activity.openTest(resultData)
+                                            },
+                                            onFailure = { println("Autoryzacja nieudana") }
+                                        )
+                                    }
                                 } else {
-                                    authenticateUser(activity,
-                                        onSuccess = {
-                                            viewModel.authenticate()
-                                            activity.openTest(resultData)
-                                        },
-                                        onFailure = { println("Autoryzacja nieudana") }
-                                    )
+                                    navigate(resultData)
                                 }
 
                             }

--- a/app/src/main/java/me/proteus/myeye/ui/VisionTestLayoutActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/VisionTestLayoutActivity.kt
@@ -46,7 +46,7 @@ class VisionTestLayoutActivity : ComponentActivity() {
 
                         val testObject: VisionTest = VisionTestUtils().getTestByID(testID)
 
-                        testObject.BeginTest(activity = this@VisionTestLayoutActivity, modifier = Modifier, isResult = isResult, result = resultData)
+                        testObject.BeginTest(activity = this@VisionTestLayoutActivity, isResult = isResult, result = resultData)
 
                     }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -25,8 +25,9 @@ class BuildTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        stages: List<SerializablePair>,
-        isResult: Boolean
+        stage: SerializablePair,
+        isResult: Boolean,
+        onUpdate: (String) -> Unit
     ) {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -1,17 +1,14 @@
 package me.proteus.myeye.visiontests
 
-import android.content.Intent
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import me.proteus.myeye.MenuActivity
 import me.proteus.myeye.SerializablePair
 import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
-import me.proteus.myeye.io.ResultDataSaver
 import me.proteus.myeye.ui.VisionTestLayoutActivity
 import java.util.Random
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
-import me.proteus.myeye.SerializablePair
+import me.proteus.myeye.SerializableStage
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -23,7 +23,7 @@ class BuildTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        stage: SerializablePair,
+        stage: SerializableStage,
         isResult: Boolean,
         onUpdate: (String) -> Unit
     ) {
@@ -38,12 +38,6 @@ class BuildTest : VisionTest {
 
     override fun checkAnswer(answer: String): Boolean {
         return true
-    }
-
-    override fun storeResult(question: String, answer: String) {
-
-        resultCollector.addResult(question, answer)
-
     }
 
     override fun getExampleAnswers(): Array<String> {

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -32,17 +32,7 @@ class BuildTest : VisionTest {
         TODO("Not yet implemented")
     }
 
-    @Composable
-    override fun BeginTest(
-        activity: VisionTestLayoutActivity,
-        modifier: Modifier,
-        isResult: Boolean,
-        result: TestResult?
-    ) {
-        TODO("Not yet implemented")
-    }
-
-    override fun generateQuestion(): Any {
+    override fun generateQuestion(): String {
 
         return "Testowy test wzroku #2 (TEST_BUILD)"
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -25,6 +25,7 @@ class BuildTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
+        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
         TODO("Not yet implemented")

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -30,7 +30,7 @@ class BuildTest : VisionTest {
         TODO("Not yet implemented")
     }
 
-    override fun generateQuestion(): String {
+    override fun generateQuestion(stage: Int?): String {
 
         return "Testowy test wzroku #2 (TEST_BUILD)"
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -25,7 +25,6 @@ class BuildTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        modifier: Modifier,
         stages: List<SerializablePair>,
         isResult: Boolean
     ) {

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -3,10 +3,8 @@ package me.proteus.myeye.visiontests
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import me.proteus.myeye.SerializablePair
-import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -136,7 +136,7 @@ class CircleTest : VisionTest {
     }
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
 
         var stageIterator: Int by remember { mutableIntStateOf(0) }
 
@@ -149,7 +149,7 @@ class CircleTest : VisionTest {
         ) {
 
             Box (
-                modifier = modifier
+                modifier = Modifier
                     .weight(1f)
                     .padding(bottom = 16.dp),
                 contentAlignment = Alignment.Center,
@@ -163,7 +163,7 @@ class CircleTest : VisionTest {
                         directions = stages[stageIterator].first,
                         key = null,
                         currentStage = stageIterator,
-                        modifier = modifier
+                        modifier = Modifier
                     )
 
                     if (isResult) {
@@ -171,7 +171,7 @@ class CircleTest : VisionTest {
                             directions = stages[stageIterator].second,
                             key = stages[stageIterator].first,
                             currentStage = stageIterator,
-                            modifier = modifier
+                            modifier = Modifier
                         )
                     }
                 }
@@ -197,7 +197,7 @@ class CircleTest : VisionTest {
                 )
             } else {
                 Row(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -210,7 +210,7 @@ class CircleTest : VisionTest {
         }
     }
 
-    override fun generateQuestion(): String {
+    override fun generateQuestion(stage: Int?): String {
 
         var question: String = generateDirections()
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -32,7 +32,6 @@ import androidx.compose.ui.unit.dp
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
 import me.proteus.myeye.SerializablePair
-import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -185,7 +184,7 @@ class CircleTest : VisionTest {
 
             if (!isResult) {
                 ButtonRow(
-                    onRegenerate = { },
+                    onRegenerate = { onUpdate("REGENERATE") },
 
                     onSizeDecrease = {
                         onUpdate(generateDirections())

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -136,35 +136,6 @@ class CircleTest : VisionTest {
     }
 
     @Composable
-    override fun BeginTest(
-        activity: VisionTestLayoutActivity,
-        modifier: Modifier,
-        isResult: Boolean,
-        result: TestResult?
-    ) {
-
-        if (isResult) {
-
-            var resultStages = ResultDataCollector.deserializeResult(result!!.result)
-
-            DisplayStage(activity, modifier, resultStages, true)
-
-        } else {
-
-            var testStages: MutableList<SerializablePair> = ArrayList<SerializablePair>()
-
-            for (i in 0..<stageCount) {
-                testStages.add(SerializablePair(this.generateQuestion().toString(), generateDirections()))
-            }
-
-            DisplayStage(activity, modifier, testStages, false)
-
-        }
-
-    }
-
-
-    @Composable
     override fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean) {
 
         var stageIterator: Int by remember { mutableIntStateOf(0) }
@@ -243,7 +214,7 @@ class CircleTest : VisionTest {
         }
     }
 
-    override fun generateQuestion(): Any {
+    override fun generateQuestion(): String {
 
         var question: String = generateDirections()
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -14,10 +14,6 @@ import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.rotate
@@ -67,7 +63,7 @@ class CircleTest : VisionTest {
         val opticianSansFamily = FontFamily(Font(R.font.opticiansans))
 
         var screenDensity = getScreenInfo(LocalContext.current).densityDpi / 2.54f
-        var calculatedSize = stageToCentimeters(currentStage, 100f)
+        var calculatedSize = stageToCentimeters(currentStage - 1, 100f)
         println(calculatedSize)
         var pixelSize = with(LocalDensity.current) { (screenDensity * calculatedSize).toSp() }
 
@@ -139,10 +135,9 @@ class CircleTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
+        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
-
-        var difficulty: Int by remember { mutableIntStateOf(0) }
 
         Column(
             modifier = Modifier
@@ -188,7 +183,6 @@ class CircleTest : VisionTest {
 
                     onSizeDecrease = {
                         onUpdate(generateDirections())
-                        difficulty++
                     }
                 )
             } else {

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -63,7 +63,7 @@ class CircleTest : VisionTest {
         val opticianSansFamily = FontFamily(Font(R.font.opticiansans))
 
         var screenDensity = getScreenInfo(LocalContext.current).densityDpi / 2.54f
-        var calculatedSize = stageToCentimeters(currentStage - 1, 100f)
+        var calculatedSize = stageToCentimeters(currentStage, 100f)
         println(calculatedSize)
         var pixelSize = with(LocalDensity.current) { (screenDensity * calculatedSize).toSp() }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
-import me.proteus.myeye.SerializablePair
+import me.proteus.myeye.SerializableStage
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -137,7 +137,7 @@ class CircleTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        stage: SerializablePair,
+        stage: SerializableStage,
         isResult: Boolean,
         onUpdate: (String) -> Unit
     ) {
@@ -198,12 +198,12 @@ class CircleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-//                    Button(onClick = { stageIterator-- }) {
-//                        Text(text = "Poprzedni etap")
-//                    }
-//                    Button(onClick = { stageIterator++ }) {
-//                        Text(text = "Następny etap")
-//                    }
+                    Button(onClick = { onUpdate("PREV") }) {
+                        Text(text = "Poprzedni etap")
+                    }
+                    Button(onClick = { onUpdate("NEXT") }) {
+                        Text(text = "Następny etap")
+                    }
                 }
             }
 
@@ -251,12 +251,6 @@ class CircleTest : VisionTest {
         arr[abs(random.nextInt()) % 4] = correctAnswer
 
         return arr
-
-    }
-
-    override fun storeResult(question: String, answer: String) {
-
-        resultCollector.addResult(question, answer)
 
     }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -136,9 +136,14 @@ class CircleTest : VisionTest {
     }
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(
+        activity: VisionTestLayoutActivity,
+        stage: SerializablePair,
+        isResult: Boolean,
+        onUpdate: (String) -> Unit
+    ) {
 
-        var stageIterator: Int by remember { mutableIntStateOf(0) }
+        var difficulty: Int by remember { mutableIntStateOf(0) }
 
         Column(
             modifier = Modifier
@@ -160,17 +165,17 @@ class CircleTest : VisionTest {
                 ) {
 
                     LetterContainer(
-                        directions = stages[stageIterator].first,
+                        directions = stage.first,
                         key = null,
-                        currentStage = stageIterator,
+                        currentStage = difficulty,
                         modifier = Modifier
                     )
 
                     if (isResult) {
                         LetterContainer(
-                            directions = stages[stageIterator].second,
-                            key = stages[stageIterator].first,
-                            currentStage = stageIterator,
+                            directions = stage.second,
+                            key = stage.first,
+                            currentStage = difficulty,
                             modifier = Modifier
                         )
                     }
@@ -180,19 +185,11 @@ class CircleTest : VisionTest {
 
             if (!isResult) {
                 ButtonRow(
-                    onRegenerate = { stageIterator++ },
+                    onRegenerate = { },
 
                     onSizeDecrease = {
-
-                        if (stageIterator < stageCount - 1) {
-
-                            // TODO: Zaimplementowac polecenia glosowe do zbierania odpowiedzi
-                            storeResult(stages[stageIterator].first, generateDirections())
-                            stageIterator++
-                        } else {
-                            storeResult(stages[stageIterator].first, generateDirections())
-                            if (!isResult) endTest(activity)
-                        }
+                        onUpdate(generateDirections())
+                        difficulty++
                     }
                 )
             } else {
@@ -202,12 +199,12 @@ class CircleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Button(onClick = { stageIterator-- }) {
-                        Text(text = "Poprzedni etap")
-                    }
-                    Button(onClick = { stageIterator++ }) {
-                        Text(text = "Następny etap")
-                    }
+//                    Button(onClick = { stageIterator-- }) {
+//                        Text(text = "Poprzedni etap")
+//                    }
+//                    Button(onClick = { stageIterator++ }) {
+//                        Text(text = "Następny etap")
+//                    }
                 }
             }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.material3.Button
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
@@ -76,23 +77,40 @@ class ColorArrangementTest : VisionTest {
         onUpdate: (String) -> Unit
     ) {
 
-        val inputColors: List<String>
-        val sortedColors: List<String>
+//        if (isResult) {
+//            inputColors = stage.second.split(' ')
+//            sortedColors = stage.first.split(' ')
+//        } else {
+//            inputColors = stage.first.split(' ')
+//            sortedColors = inputColors.sortedBy { getHue(it) }
+//        }
+//
 
-        if (isResult) {
-            inputColors = stage.second.split(' ')
-            sortedColors = stage.first.split(' ')
-        } else {
-            inputColors = stage.first.split(' ')
-            sortedColors = inputColors.sortedBy { getHue(it) }
+
+        val inputColors by remember(stage) {
+            derivedStateOf {
+                if (isResult) stage.second.split(' ')
+                else stage.first.split(' ')
+            }
         }
 
-        var stageColors by remember {
-            mutableStateOf(inputColors)
+        val sortedColors by remember(stage) {
+            derivedStateOf {
+                if (isResult) stage.first.split(' ')
+                else inputColors.sortedBy { getHue(it) }
+            }
         }
+
+        var stageColors by remember { mutableStateOf(inputColors) }
+
+        var correctnessMap by remember { mutableStateOf<Map<Int, Int>>(emptyMap()) }
 
         LaunchedEffect(inputColors) {
             stageColors = inputColors
+            if (isResult) {
+                correctnessMap = getCorrectnessMapping(sortedColors, stageColors)
+            }
+
         }
 
         var currentlyDragged by remember { mutableStateOf<Int?>(null) }
@@ -222,7 +240,6 @@ class ColorArrangementTest : VisionTest {
                                 println("$startX $startY")
                             }
                     ) {
-                        var correctnessMap = getCorrectnessMapping(sortedColors, stageColors)
 
                         Canvas(
                             modifier = Modifier.fillMaxSize()
@@ -302,7 +319,6 @@ class ColorArrangementTest : VisionTest {
                 ) {
                     Button(
                         onClick = {
-                            println(stageColors)
                             onUpdate(stageColors.joinToString(" "))
                         }
                     ) {
@@ -488,7 +504,6 @@ class ColorArrangementTest : VisionTest {
         while (i < a.size - 1) {
 
             var idx = b.indexOf(a[i])
-            println("index $idx")
             var j = 0
 
             while(idx + j < a.size && connected.indexOf(a.subList(idx, idx+j).joinToString(" ")) != -1) j++

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -69,8 +69,9 @@ class ColorArrangementTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        stages: List<SerializablePair>,
-        isResult: Boolean
+        stage: SerializablePair,
+        isResult: Boolean,
+        onUpdate: (String) -> Unit
     ) {
 
         var difficulty: Int by remember { mutableIntStateOf(1) }
@@ -79,11 +80,10 @@ class ColorArrangementTest : VisionTest {
         var colorArray: ArrayList<String> = ArrayList()
         var answerArray: ArrayList<String> = ArrayList()
 
-
-        for (i in stages) {
-            colorArray.add(if (isResult) i.second else i.first)
-            answerArray.add(if (isResult) i.first else i.second)
-        }
+//        for (i in stages) {
+//            colorArray.add(if (isResult) i.second else i.first)
+//            answerArray.add(if (isResult) i.first else i.second)
+//        }
 
         var stageColors by remember { mutableStateOf(
             (if (isResult) colorArray[resultIterator].split(' ') else
@@ -315,8 +315,6 @@ class ColorArrangementTest : VisionTest {
                             return@Button
 
                         }
-
-                        println("ohioskibidi")
 
                         if (difficulty < stageCount) {
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.zIndex
 import me.proteus.myeye.R
 import me.proteus.myeye.SerializablePair
-import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -62,7 +62,7 @@ class ColorArrangementTest : VisionTest {
     override val stageCount: Int = 6
     override val resultCollector: ResultDataCollector = ResultDataCollector()
 
-    val difficultyScale = listOf(8, 7, 5, 4, 3, 2, 1)
+    val difficultyScale = listOf(7, 6, 5, 4, 3, 2, 1)
     var colorOffset = 0
 
     var colors: Array<String> = arrayOf()
@@ -92,7 +92,7 @@ class ColorArrangementTest : VisionTest {
         }
 
         LaunchedEffect(inputColors) {
-            stageColors = inputColors.shuffled()
+            stageColors = inputColors
         }
 
         var currentlyDragged by remember { mutableStateOf<Int?>(null) }
@@ -301,7 +301,10 @@ class ColorArrangementTest : VisionTest {
                     contentAlignment = Alignment.Center
                 ) {
                     Button(
-                        onClick = { onUpdate(stageColors.joinToString(" ")) }
+                        onClick = {
+                            println(stageColors)
+                            onUpdate(stageColors.joinToString(" "))
+                        }
                     ) {
                         Text("Dalej")
                     }
@@ -373,10 +376,13 @@ class ColorArrangementTest : VisionTest {
 
                 } else {
                     println("Answer: $answer")
-                    storeResult(currentStage.first, answer, currentDifficulty)
+
+                    var correct = answer.split(' ').sortedBy { getHue(it) }.joinToString(" ")
+
+                    storeResult(correct, answer, currentDifficulty)
                     if (currentDifficulty < stageCount) currentDifficulty++
                     else {
-                        storeResult(currentStage.first, answer, currentDifficulty)
+                        storeResult(correct, answer, currentDifficulty)
                         endTest(activity)
                     }
                 }
@@ -477,9 +483,6 @@ class ColorArrangementTest : VisionTest {
 
         var map: MutableMap<Int, Int> = HashMap()
         var connected = b.joinToString(" ")
-
-        println(a)
-        println(b)
 
         var i = 1
         while (i < a.size - 1) {

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -359,41 +359,6 @@ class ColorArrangementTest : VisionTest {
 
     }
 
-    @Composable
-    override fun BeginTest(
-        activity: VisionTestLayoutActivity,
-        modifier: Modifier,
-        isResult: Boolean,
-        result: TestResult?
-    ) {
-        colors = activity.resources.getStringArray(R.array.farnsworth_colors)
-
-        if (!isResult) {
-
-            var list: MutableList<SerializablePair> = ArrayList<SerializablePair>(stageCount)
-
-            for (i in colors) {
-                list.add(SerializablePair(i, ""))
-            }
-
-            DisplayStage(activity, modifier, list, false)
-
-        } else {
-
-            var inputList = ResultDataCollector.deserializeResult(result!!.result)
-
-            var list = ArrayList<SerializablePair>()
-
-            for (el in inputList) {
-                list.add(SerializablePair(el.first, el.second))
-            }
-
-            DisplayStage(activity, modifier, list, true)
-
-        }
-
-    }
-
     override fun generateQuestion(): String {
         TODO("Not yet implemented")
     }

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -355,56 +355,7 @@ class ColorArrangementTest : VisionTest {
     ) {
         colors = activity.resources.getStringArray(R.array.farnsworth_colors)
 
-        if (isResult) {
-            var i by remember { mutableIntStateOf(0) }
-
-            val resultData = ResultDataCollector.deserializeResult(result!!.result)
-            var stageList = remember { resultData }
-
-            var currentResultStage = stageList[i]
-            var stageDifficuly = currentResultStage.difficulty
-
-            DisplayStage(activity, currentResultStage, true, stageDifficuly) { answer ->
-                if (answer == "PREV") {
-                    if (i > 0) i--
-                } else if (answer == "NEXT") {
-                    if (i < stageList.size - 1) i++
-                    // else powrot do menu
-                }
-            }
-
-        } else {
-
-            var currentDifficulty by remember { mutableIntStateOf(0) }
-            var currentStage = SerializableStage(
-                generateQuestion(currentDifficulty).toString(),
-                getExampleAnswers().joinToString(" "), currentDifficulty
-            )
-            DisplayStage(activity, currentStage, false, currentDifficulty) { answer ->
-
-                if (answer == "REGENERATE") {
-
-                    currentStage = SerializableStage(
-                        generateQuestion(currentDifficulty).toString(),
-                        getExampleAnswers().joinToString(" "), currentDifficulty
-                    )
-                    println("Regenerate")
-
-                } else {
-                    println("Answer: $answer")
-
-                    var correct = answer.split(' ').sortedBy { getHue(it) }.joinToString(" ")
-
-                    storeResult(correct, answer, currentDifficulty)
-                    if (currentDifficulty < stageCount) currentDifficulty++
-                    else {
-                        storeResult(correct, answer, currentDifficulty)
-                        endTest(activity)
-                    }
-                }
-
-
-            }
+        BeginTestImpl(activity, isResult, result)
 
 //            var a = getScore(answer, "RELATIVE")
 //            var b = getScore(answer, "LEVENSHTEIN")

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -69,7 +69,6 @@ class ColorArrangementTest : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        modifier: Modifier,
         stages: List<SerializablePair>,
         isResult: Boolean
     ) {

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -187,7 +187,7 @@ class ColorArrangementTest : VisionTest {
                                 .scale(if (index == currentlyDragged) 1.5f else 1f, 1f)
                                 .zIndex((if (index == currentlyDragged) 1f else 0f))
                                 .draggable(
-                                    enabled = (!(isTopEdge || isBottomEdge)),
+                                    enabled = (!(isTopEdge || isBottomEdge || isResult)),
                                     orientation = Orientation.Vertical,
                                     state = rememberDraggableState { delta ->
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -286,7 +286,9 @@ class ColorArrangementTest : VisionTest {
                 ) {
                     Button(
                         onClick = {
-                            onUpdate(stageColors.joinToString(" "))
+                            var ans = stageColors.joinToString(" ")
+                            println(getScore(ans, "RELATIVE"))
+                            onUpdate(ans)
                         }
                     ) {
                         Text("Dalej")
@@ -323,22 +325,6 @@ class ColorArrangementTest : VisionTest {
         colors = activity.resources.getStringArray(R.array.farnsworth_colors)
 
         BeginTestImpl(activity, isResult, result)
-
-//            var a = getScore(answer, "RELATIVE")
-//            var b = getScore(answer, "LEVENSHTEIN")
-//
-//            var srednia = (a + b) / 2
-//
-//            if (srednia >= 70 && srednia < 100 && difficulty >= 4) {
-//                colorOffset += 20
-//                println("${(a + b) / 2} Bez zmiany trudnosci")
-//            } else {
-//                colorOffset = 0
-//                difficulty++
-//            }
-//            var correct = answer.split(" ").sortedBy { getHue(it) }.joinToString(" ")
-//
-//            storeResult(correct, answer)
 
             // zwieksz colorOffset gdy wynik jest bliski 100
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -394,7 +394,7 @@ class ColorArrangementTest : VisionTest {
 
     }
 
-    override fun generateQuestion(): Any {
+    override fun generateQuestion(): String {
         TODO("Not yet implemented")
     }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -1,6 +1,5 @@
 package me.proteus.myeye.visiontests
 
-import android.content.Intent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,12 +22,10 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import me.proteus.myeye.MenuActivity
 import me.proteus.myeye.SerializablePair
 import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
-import me.proteus.myeye.io.ResultDataSaver
 import me.proteus.myeye.ui.VisionTestLayoutActivity
 import java.util.Random
 import kotlin.math.abs
@@ -44,46 +41,6 @@ class ExampleTest : VisionTest {
     override val stageCount: Int = 10
 
     override val resultCollector: ResultDataCollector = ResultDataCollector()
-
-
-    @Composable
-    override fun BeginTest(
-        activity: VisionTestLayoutActivity,
-        modifier: Modifier,
-        isResult: Boolean,
-        result: TestResult?
-    ) {
-
-        if (isResult) {
-
-            var resultStages: MutableList<SerializablePair> = ArrayList<SerializablePair>()
-            val resultData = ResultDataCollector.deserializeResult(result!!.result)
-
-            for (i in 0..stageCount-1) {
-                resultStages.add(resultData[i])
-            }
-
-            DisplayStage(activity, modifier, resultStages, true)
-
-        } else {
-
-            var testStages: MutableList<SerializablePair> = ArrayList<SerializablePair>()
-
-            for (i in 0..stageCount-1) {
-
-                correctAnswer = this.generateQuestion().toString()
-
-                var variants = this.getExampleAnswers()
-                var joinedVariants = variants.joinToString(separator = "")
-
-                testStages.add(SerializablePair(correctAnswer, joinedVariants))
-            }
-
-            DisplayStage(activity, modifier, testStages, false)
-
-        }
-
-    }
 
     @Composable
     override fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean) {
@@ -182,9 +139,9 @@ class ExampleTest : VisionTest {
 
     override fun generateQuestion(): Any {
 
-        var question = randomChar()
+        var question = randomChar().toString()
 
-        correctAnswer = question.toString()
+        correctAnswer = question
 
         return question
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -38,7 +38,13 @@ class ExampleTest : VisionTest {
     override val resultCollector: ResultDataCollector = ResultDataCollector()
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, stage: SerializableStage, isResult: Boolean, onUpdate: (String) -> Unit) {
+    override fun DisplayStage(
+        activity: VisionTestLayoutActivity,
+        stage: SerializableStage,
+        isResult: Boolean,
+        difficulty: Int,
+        onUpdate: (String) -> Unit
+    ) {
 
         println("$score")
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -119,7 +119,7 @@ class ExampleTest : VisionTest {
 
     }
 
-    override fun generateQuestion(): String {
+    override fun generateQuestion(stage: Int?): String {
 
         var question = randomChar().toString()
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -12,10 +12,6 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -23,7 +19,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import me.proteus.myeye.SerializablePair
-import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -137,7 +137,7 @@ class ExampleTest : VisionTest {
 
     }
 
-    override fun generateQuestion(): Any {
+    override fun generateQuestion(): String {
 
         var question = randomChar().toString()
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -43,7 +43,7 @@ class ExampleTest : VisionTest {
     override val resultCollector: ResultDataCollector = ResultDataCollector()
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
 
         var stageIterator: Int by remember { mutableIntStateOf(0) }
 
@@ -61,7 +61,7 @@ class ExampleTest : VisionTest {
                 Text(text = score.toString())
             }
             Box (
-                modifier = modifier
+                modifier = Modifier
                     .weight(1f)
                     .padding(bottom = 32.dp),
                 contentAlignment = Alignment.Center,
@@ -91,7 +91,7 @@ class ExampleTest : VisionTest {
 
             if (!isResult) {
                 Row(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
@@ -119,7 +119,7 @@ class ExampleTest : VisionTest {
                 }
             } else {
                 Row(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import me.proteus.myeye.SerializablePair
+import me.proteus.myeye.SerializableStage
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -38,7 +38,7 @@ class ExampleTest : VisionTest {
     override val resultCollector: ResultDataCollector = ResultDataCollector()
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, stage: SerializablePair, isResult: Boolean, onUpdate: (String) -> Unit) {
+    override fun DisplayStage(activity: VisionTestLayoutActivity, stage: SerializableStage, isResult: Boolean, onUpdate: (String) -> Unit) {
 
         println("$score")
 
@@ -106,12 +106,12 @@ class ExampleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-//                    Button(onClick = { stageIterator-- }) {
-//                        Text(text = "Poprzedni etap")
-//                    }
-//                    Button(onClick = { stageIterator++ }) {
-//                        Text(text = "Następny etap")
-//                    }
+                    Button(onClick = { onUpdate("PREV") }) {
+                        Text(text = "Poprzedni etap")
+                    }
+                    Button(onClick = { onUpdate("NEXT") }) {
+                        Text(text = "Następny etap")
+                    }
                 }
             }
 
@@ -131,12 +131,6 @@ class ExampleTest : VisionTest {
 
     override fun checkAnswer(answer: String): Boolean {
         return answer == correctAnswer
-    }
-
-    override fun storeResult(question: String, answer: String) {
-
-        resultCollector.addResult(question, answer)
-
     }
 
     override fun getExampleAnswers(): Array<String> {

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -96,7 +96,8 @@ class ExampleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    for (el in stages[stageIterator].second) {
+                    var buttons = stages[stageIterator].second.filter { it != ' ' }
+                    for (el in buttons) {
 
                         var ans: String = el.toString()
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -43,11 +43,9 @@ class ExampleTest : VisionTest {
     override val resultCollector: ResultDataCollector = ResultDataCollector()
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(activity: VisionTestLayoutActivity, stage: SerializablePair, isResult: Boolean, onUpdate: (String) -> Unit) {
 
-        var stageIterator: Int by remember { mutableIntStateOf(0) }
-
-        println("$score $stageIterator")
+        println("$score")
 
         Column(
             modifier = Modifier
@@ -71,15 +69,15 @@ class ExampleTest : VisionTest {
                     horizontalArrangement = Arrangement.spacedBy(16.dp)
                 ) {
                     Text(
-                        text = stages[stageIterator].first,
+                        text = stage.first,
                         color = Color.Black,
                         fontSize = 48.sp
                     )
 
                     if (isResult) {
                         Text(
-                            text = stages[stageIterator].second,
-                            color = (if (stages[stageIterator].first == stages[stageIterator].second) Color.Green else Color.Red),
+                            text = stage.second,
+                            color = (if (stage.first == stage.second) Color.Green else Color.Red),
                             fontSize = 48.sp
                         )
                     }
@@ -96,24 +94,12 @@ class ExampleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    var buttons = stages[stageIterator].second.filter { it != ' ' }
+                    var buttons = stage.second.filter { it != ' ' }
                     for (el in buttons) {
 
                         var ans: String = el.toString()
 
-                        Button(onClick = {
-
-                            if (ans == stages[stageIterator].first) score++
-
-                            if (stageIterator < stageCount - 1) {
-                                storeResult(stages[stageIterator].first, ans)
-                                stageIterator++
-                            } else {
-                                storeResult(stages[stageIterator].first, ans)
-                                if (!isResult) endTest(activity)
-                            }
-
-                        }) {
+                        Button(onClick = { onUpdate(ans) }) {
                             Text(if (isResult) "Dalej" else ans)
                         }
                     }
@@ -125,12 +111,12 @@ class ExampleTest : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Button(onClick = { stageIterator-- }) {
-                        Text(text = "Poprzedni etap")
-                    }
-                    Button(onClick = { stageIterator++ }) {
-                        Text(text = "Następny etap")
-                    }
+//                    Button(onClick = { stageIterator-- }) {
+//                        Text(text = "Poprzedni etap")
+//                    }
+//                    Button(onClick = { stageIterator++ }) {
+//                        Text(text = "Następny etap")
+//                    }
                 }
             }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -30,7 +30,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
-import me.proteus.myeye.SerializablePair
+import me.proteus.myeye.SerializableStage
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -132,12 +132,11 @@ class SnellenChart : VisionTest {
     @Composable
     override fun DisplayStage(
         activity: VisionTestLayoutActivity,
-        stage: SerializablePair,
+        stage: SerializableStage,
         isResult: Boolean,
+        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
-
-        var difficulty by remember { mutableIntStateOf(0) }
 
         Column(
             modifier = Modifier
@@ -180,7 +179,6 @@ class SnellenChart : VisionTest {
                     onRegenerate = { onUpdate("REGENERATE") },
                     onSizeDecrease = {
                         onUpdate(randomText(5))
-                        difficulty++
                     }
                 )
             } else {
@@ -191,22 +189,16 @@ class SnellenChart : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-//                    Button(onClick = { questionIterator-- }) {
-//                        Text(text = "Poprzedni etap")
-//                    }
-//                    Button(onClick = { questionIterator++ }) {
-//                        Text(text = "Następny etap")
-//                    }
+                    Button(onClick = { onUpdate("PREV") }) {
+                        Text(text = "Poprzedni etap")
+                    }
+                    Button(onClick = { onUpdate("NEXT") }) {
+                        Text(text = "Następny etap")
+                    }
                 }
             }
 
         }
-    }
-
-    override fun storeResult(question: String, answer: String) {
-
-        resultCollector.addResult(question, answer)
-
     }
 
     override fun generateQuestion(stage: Int?): String {

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -130,9 +130,14 @@ class SnellenChart : VisionTest {
     }
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(
+        activity: VisionTestLayoutActivity,
+        stage: SerializablePair,
+        isResult: Boolean,
+        onUpdate: (String) -> Unit
+    ) {
 
-        var questionIterator: Int by remember { mutableIntStateOf(0) }
+        var difficulty by remember { mutableIntStateOf(0) }
 
         Column(
             modifier = Modifier
@@ -152,16 +157,16 @@ class SnellenChart : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
                     LetterContainer(
-                        stage = questionIterator,
-                        text = stages[questionIterator].first,
+                        stage = difficulty,
+                        text = stage.first,
                         key = null,
                         modifier = Modifier
                     )
                     if (isResult) {
                         LetterContainer(
-                            stage = questionIterator,
-                            text = stages[questionIterator].second,
-                            key = stages[questionIterator].first,
+                            stage = difficulty,
+                            text = stage.second,
+                            key = stage.first,
                             modifier = Modifier
                         )
                     }
@@ -172,19 +177,10 @@ class SnellenChart : VisionTest {
 
             if (!isResult) {
                 ButtonRow(
-                    onRegenerate = { questionIterator++ },
+                    onRegenerate = { },
                     onSizeDecrease = {
-
-                        if (questionIterator < stageCount - 1) {
-
-                            // TODO: Zaimplementowac polecenia glosowe do zbierania odpowiedzi
-                            storeResult(stages[questionIterator].first, randomText(5))
-                            questionIterator++
-                        } else {
-                            storeResult(stages[questionIterator].first, randomText(5))
-                            if (!isResult) endTest(activity)
-
-                        }
+                        onUpdate(randomText(5))
+                        difficulty++
                     }
                 )
             } else {
@@ -195,12 +191,12 @@ class SnellenChart : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    Button(onClick = { questionIterator-- }) {
-                        Text(text = "Poprzedni etap")
-                    }
-                    Button(onClick = { questionIterator++ }) {
-                        Text(text = "Następny etap")
-                    }
+//                    Button(onClick = { questionIterator-- }) {
+//                        Text(text = "Poprzedni etap")
+//                    }
+//                    Button(onClick = { questionIterator++ }) {
+//                        Text(text = "Następny etap")
+//                    }
                 }
             }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -1,6 +1,5 @@
 package me.proteus.myeye.visiontests
 
-import android.content.Intent
 import android.content.res.Configuration
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -32,7 +31,6 @@ import androidx.compose.ui.unit.dp
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
 import me.proteus.myeye.SerializablePair
-import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.ui.VisionTestLayoutActivity
@@ -127,41 +125,6 @@ class SnellenChart : VisionTest {
             Button(onClick = { onSizeDecrease() }) {
                 Text(text = "Dalej")
             }
-        }
-
-    }
-
-    @Composable
-    override fun BeginTest(
-        activity: VisionTestLayoutActivity,
-        modifier: Modifier,
-        isResult: Boolean,
-        result: TestResult?
-    ) {
-
-        if (isResult) {
-
-            var resultStages: MutableList<SerializablePair> = ArrayList<SerializablePair>(stageCount)
-
-            val resultData = ResultDataCollector.deserializeResult(result!!.result)
-
-
-            for (i in 0..<stageCount) {
-                resultStages.add(resultData[i])
-            }
-
-            DisplayStage(activity, modifier, resultStages, true)
-
-        } else {
-
-            var testStages: MutableList<SerializablePair> = ArrayList<SerializablePair>(stageCount)
-
-            for (i in 0..<stageCount) {
-                testStages.add(SerializablePair(this.generateQuestion().toString(), randomText(5)))
-            }
-
-            DisplayStage(activity, modifier, testStages, false)
-
         }
 
     }

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -209,7 +209,7 @@ class SnellenChart : VisionTest {
 
     }
 
-    override fun generateQuestion(): String {
+    override fun generateQuestion(stage: Int?): String {
 
         var question: String = randomText(5)
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -177,7 +177,7 @@ class SnellenChart : VisionTest {
 
             if (!isResult) {
                 ButtonRow(
-                    onRegenerate = { },
+                    onRegenerate = { onUpdate("REGENERATE") },
                     onSizeDecrease = {
                         onUpdate(randomText(5))
                         difficulty++

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -130,7 +130,7 @@ class SnellenChart : VisionTest {
     }
 
     @Composable
-    override fun DisplayStage(activity: VisionTestLayoutActivity, modifier: Modifier, stages: List<SerializablePair>, isResult: Boolean) {
+    override fun DisplayStage(activity: VisionTestLayoutActivity, stages: List<SerializablePair>, isResult: Boolean) {
 
         var questionIterator: Int by remember { mutableIntStateOf(0) }
 
@@ -143,7 +143,7 @@ class SnellenChart : VisionTest {
         ) {
 
             Box (
-                modifier = modifier
+                modifier = Modifier
                     .weight(1f)
                     .padding(bottom = 16.dp),
                 contentAlignment = Alignment.Center,
@@ -155,14 +155,14 @@ class SnellenChart : VisionTest {
                         stage = questionIterator,
                         text = stages[questionIterator].first,
                         key = null,
-                        modifier = modifier
+                        modifier = Modifier
                     )
                     if (isResult) {
                         LetterContainer(
                             stage = questionIterator,
                             text = stages[questionIterator].second,
                             key = stages[questionIterator].first,
-                            modifier = modifier
+                            modifier = Modifier
                         )
                     }
 
@@ -190,7 +190,7 @@ class SnellenChart : VisionTest {
             } else {
 
                 Row(
-                    modifier = modifier
+                    modifier = Modifier
                         .fillMaxWidth(),
                     horizontalArrangement = Arrangement.SpaceEvenly,
                     verticalAlignment = Alignment.CenterVertically

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -213,7 +213,7 @@ class SnellenChart : VisionTest {
 
     }
 
-    override fun generateQuestion(): Any {
+    override fun generateQuestion(): String {
 
         var question: String = randomText(5)
 


### PR DESCRIPTION
W aktualizacji 0.8.2 skupiłem się na ulepszaniu różnych elementów systemu testów. Oto niektóre z nich:
 - Nowa klasa `ASRViewModel` - Implementacja Vosk (przeniesiona ze `SpeechDecoderActivity`), zbierająca i przechowująca wypowiedziane słowa i zawierająca niestandardową pulę gramatyczną (domyślnie dla języka polskiego) zoptymalizowaną pod wymagania testów,
 - Zmiana `SerializablePair` na `SerializableStage` - dodano informację o poziomie trudności,
 - Usprawniono przekazywanie pytań - od teraz `DisplayStage` przyjmuje tylko jeden etap na raz (w oparciu o nowy system poziomów trudności zamiast stage iterators) i może zwracać wartości przez callback (np. do powtórzenia etapu lub nawigacji w widoku wyniku),
 - `BeginTest` jest teraz wrapperem dla nowej metody `BeginTestImpl`, żeby było łatwiej w klasach `VisionTest` wczytywać zasoby R lub pliki na początku testu,
 - Zmiana `SerializablePair` na `SerializableStage` - dodano informację o poziomie trudności,
 - Nowa intencja - po zakończeniu przeglądania wyniku testu następuje teraz przejście do `MenuActivity` (Zrobione TODO z #5)
 - Tymczasowo wyłączone zostało uwierzytelnianie biometryczne - żeby łatwiej było testować na emulatorze,
 - Różne poprawki UI i logiki testu Farnswortha-Munsella.

**To Do:**
 - Ciąg dalszy wdrażania `ASRViewModel` do testów wzroku - prawdopodobnie potrzebny będzie bardziej złożony system wczytywania odpowiedzi (w teście mogłoby być pole np. `answerType` - do wyboru: głos, przyciski lub coś jeszcze innego),
 - Optymalizacja `Gr.fst` i `HCLr.fst` pod specyficzne wymagania projektu,
 - Lepsza nawigacja w UI