### PR TITLE
Update 0.8.3: ASR w testach i wybór języka

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -66,6 +66,7 @@ dependencies {
     implementation(libs.gson)
     implementation(libs.async.http.client)
     implementation(libs.zip4j)
+    implementation(libs.slf4j.simple)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:name=".MyEyeApplication"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.MyEye"

--- a/app/src/main/java/me/proteus/myeye/GrammarType.kt
+++ b/app/src/main/java/me/proteus/myeye/GrammarType.kt
@@ -1,0 +1,10 @@
+package me.proteus.myeye
+
+enum class GrammarType(val items: List<String>) {
+
+    LETTERS(listOf("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z")),
+    LETTERS_LOGMAR(listOf("c", "d", "h", "k", "n", "o", "r", "s", "v", "z")),
+    NUMBERS(listOf("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "zero")),
+    SIDES(listOf("top", "bottom", "left", "right"))
+
+}

--- a/app/src/main/java/me/proteus/myeye/LanguageUtils.java
+++ b/app/src/main/java/me/proteus/myeye/LanguageUtils.java
@@ -1,0 +1,34 @@
+package me.proteus.myeye;
+
+import android.content.Context;
+import android.content.SharedPreferences;
+import android.content.res.Configuration;
+import android.util.Log;
+import java.util.Locale;
+
+class LanguageUtils {
+
+    static String getCurrentLanguage(Context context) {
+        SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
+        return prefs.getString("lang", "en");
+    }
+
+     static void saveLanguage(Context context, String language) {
+        SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
+        prefs.edit().putString("lang", language).apply();
+        Log.e("MyEyeApplication", "getCurrentLanguage: " + getCurrentLanguage(context));
+    }
+
+    static Context setLocale(Context context, String lang) {
+
+        Locale locale = new Locale(lang);
+        Locale.setDefault(locale);
+
+        Configuration config = new Configuration(context.getResources().getConfiguration());
+        config.setLocale(locale);
+
+        return context.createConfigurationContext(config);
+
+    }
+
+}

--- a/app/src/main/java/me/proteus/myeye/LanguageUtils.java
+++ b/app/src/main/java/me/proteus/myeye/LanguageUtils.java
@@ -3,28 +3,32 @@ package me.proteus.myeye;
 import android.content.Context;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.util.Log;
 import java.util.Locale;
 
-class LanguageUtils {
+public class LanguageUtils {
 
-    static String getCurrentLanguage(Context context) {
+    public static String getCurrentLanguage(Context context) {
         SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
         return prefs.getString("lang", "en");
     }
 
-     static void saveLanguage(Context context, String language) {
+     public static void saveLanguage(Context context, String language) {
         SharedPreferences prefs = context.getSharedPreferences("app_prefs", Context.MODE_PRIVATE);
         prefs.edit().putString("lang", language).apply();
         Log.e("MyEyeApplication", "getCurrentLanguage: " + getCurrentLanguage(context));
     }
 
-    static Context setLocale(Context context, String lang) {
+    public static Context setLocale(Context context, String lang) {
 
         Locale locale = new Locale(lang);
         Locale.setDefault(locale);
 
-        Configuration config = new Configuration(context.getResources().getConfiguration());
+        Resources resources = context.getResources();
+        Configuration resConfig = resources.getConfiguration();
+
+        Configuration config = new Configuration(resConfig);
         config.setLocale(locale);
 
         return context.createConfigurationContext(config);

--- a/app/src/main/java/me/proteus/myeye/LanguageUtils.kt
+++ b/app/src/main/java/me/proteus/myeye/LanguageUtils.kt
@@ -1,0 +1,4 @@
+package me.proteus.myeye
+
+class LanguageUtils {
+}

--- a/app/src/main/java/me/proteus/myeye/LanguageUtils.kt
+++ b/app/src/main/java/me/proteus/myeye/LanguageUtils.kt
@@ -1,4 +1,0 @@
-package me.proteus.myeye
-
-class LanguageUtils {
-}

--- a/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
+++ b/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
@@ -4,42 +4,27 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
-import android.content.res.Configuration
-import me.proteus.myeye.ui.SpeechDecoderActivity
-import java.util.Locale
+import android.util.Log
 
 class MyEyeApplication : Application() {
 
-    val languages = listOf("pl", "en")
-    var currentLang = 0
+    override fun onCreate() {
+        super.onCreate()
+        Log.e("MyEyeApplication", "onCreate: App created")
+    }
 
     override fun attachBaseContext(base: Context) {
-        val prefs = base.getSharedPreferences("app_prefs", MODE_PRIVATE)
-        val language = prefs.getString("lang", "en") ?: "en"
-        val newContext = setLocale(base, language)
+        val currentLang = LanguageUtils.getCurrentLanguage(base)
+        val newContext = LanguageUtils.setLocale(base, currentLang)
+        Log.e("MyEyeApplication", "attachBaseContext: Context attached")
         super.attachBaseContext(newContext)
-    }
-
-    private fun saveLanguage(context: Context, language: String) {
-        val prefs = context.getSharedPreferences("app_prefs", MODE_PRIVATE)
-        prefs.edit().putString("lang", language).apply()
-    }
-
-    private fun setLocale(context: Context, lang: String): Context {
-
-        val locale = Locale(lang)
-        Locale.setDefault(locale)
-
-        val config = Configuration(context.resources.configuration)
-        config.setLocale(locale)
-
-        return context.createConfigurationContext(config)
-
     }
 
     fun setAppLanguage(activity: Activity, language: String) {
 
-        val intent = Intent(activity, SpeechDecoderActivity::class.java)
+        LanguageUtils.saveLanguage(activity, language)
+
+        val intent = activity.intent
         intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
         activity.startActivity(intent)
         activity.finish()

--- a/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
+++ b/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
@@ -1,6 +1,49 @@
 package me.proteus.myeye
 
+import android.app.Activity
 import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.content.res.Configuration
+import me.proteus.myeye.ui.SpeechDecoderActivity
+import java.util.Locale
 
 class MyEyeApplication : Application() {
+
+    val languages = listOf("pl", "en")
+    var currentLang = 0
+
+    override fun attachBaseContext(base: Context) {
+        val prefs = base.getSharedPreferences("app_prefs", MODE_PRIVATE)
+        val language = prefs.getString("lang", "en") ?: "en"
+        val newContext = setLocale(base, language)
+        super.attachBaseContext(newContext)
+    }
+
+    private fun saveLanguage(context: Context, language: String) {
+        val prefs = context.getSharedPreferences("app_prefs", MODE_PRIVATE)
+        prefs.edit().putString("lang", language).apply()
+    }
+
+    private fun setLocale(context: Context, lang: String): Context {
+
+        val locale = Locale(lang)
+        Locale.setDefault(locale)
+
+        val config = Configuration(context.resources.configuration)
+        config.setLocale(locale)
+
+        return context.createConfigurationContext(config)
+
+    }
+
+    fun setAppLanguage(activity: Activity, language: String) {
+
+        val intent = Intent(activity, SpeechDecoderActivity::class.java)
+        intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP or Intent.FLAG_ACTIVITY_NEW_TASK)
+        activity.startActivity(intent)
+        activity.finish()
+
+    }
+
 }

--- a/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
+++ b/app/src/main/java/me/proteus/myeye/MyEyeApplication.kt
@@ -1,0 +1,6 @@
+package me.proteus.myeye
+
+import android.app.Application
+
+class MyEyeApplication : Application() {
+}

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -1,6 +1,7 @@
 package me.proteus.myeye
 
 import android.content.Intent
+import android.util.Log
 import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -1,8 +1,8 @@
 package me.proteus.myeye
 
 import android.content.Intent
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
@@ -13,7 +13,6 @@ import me.proteus.myeye.io.ResultDataCollector
 import me.proteus.myeye.io.ResultDataSaver
 import me.proteus.myeye.ui.TestResultActivity
 import me.proteus.myeye.ui.VisionTestLayoutActivity
-import me.proteus.myeye.visiontests.ColorArrangementTest
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
@@ -39,7 +38,7 @@ interface VisionTest {
     )
 
     @Composable
-    fun BeginTest(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?) {
+    fun BeginTest(activity: VisionTestLayoutActivity, isResult: Boolean, result: TestResult?, rpl: ActivityResultLauncher<String>?) {
         BeginTestImpl(activity, isResult, result)
     }
 
@@ -55,6 +54,7 @@ interface VisionTest {
             var currentResultStage = stageList[i]
 
             DisplayStage(activity, currentResultStage, true) { answer ->
+                println(answer)
                 print("Update")
                 if (answer == "PREV") {
                     if (i > 0) i--
@@ -86,7 +86,7 @@ interface VisionTest {
                 } else if (currentDifficulty == stageCount) {
 
                     storeResult(currentStage.first, answer, currentDifficulty)
-                    endTest(activity)
+                    endTest(activity, false)
 
                 } else {
                     storeResult(currentStage.first, answer, currentDifficulty)
@@ -118,7 +118,7 @@ interface VisionTest {
         resultCollector.addResult(question, answer, difficulty)
     }
 
-     fun endTest(activity: VisionTestLayoutActivity) {
+     fun endTest(activity: VisionTestLayoutActivity, isExit: Boolean) {
 
          var localSaver = ResultDataSaver(activity.applicationContext)
 

--- a/app/src/main/java/me/proteus/myeye/VisionTest.kt
+++ b/app/src/main/java/me/proteus/myeye/VisionTest.kt
@@ -54,8 +54,7 @@ interface VisionTest {
             var currentResultStage = stageList[i]
 
             DisplayStage(activity, currentResultStage, true) { answer ->
-                println(answer)
-                print("Update")
+
                 if (answer == "PREV") {
                     if (i > 0) i--
                 } else if (answer == "NEXT") {
@@ -120,17 +119,18 @@ interface VisionTest {
 
      fun endTest(activity: VisionTestLayoutActivity, isExit: Boolean) {
 
-         var localSaver = ResultDataSaver(activity.applicationContext)
+         if (!isExit) {
+             var localSaver = ResultDataSaver(activity.applicationContext)
 
-         var timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
-         localSaver.insert(this.testID, this.resultCollector.stages, timestamp)
+             var timestamp = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
+             localSaver.insert(this.testID, this.resultCollector.stages, timestamp)
 
-         val testLeavingIntent = Intent(activity, TestResultActivity::class.java)
-         testLeavingIntent.putExtra("IS_AFTER", true)
-         testLeavingIntent.putExtra("RESULT_PARCEL", localSaver.lastResult)
+             val testLeavingIntent = Intent(activity, TestResultActivity::class.java)
+             testLeavingIntent.putExtra("IS_AFTER", true)
+             testLeavingIntent.putExtra("RESULT_PARCEL", localSaver.lastResult)
 
-         activity.startActivity(testLeavingIntent)
-
+             activity.startActivity(testLeavingIntent)
+         }
     }
 
 }

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -2,6 +2,7 @@ package me.proteus.myeye.io
 
 import android.annotation.SuppressLint
 import android.app.Application
+import android.content.Context
 import android.media.AudioFormat
 import android.media.AudioRecord
 import android.media.MediaRecorder
@@ -9,6 +10,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.AndroidViewModel
+import me.proteus.myeye.LanguageUtils
 import org.vosk.Model
 import org.vosk.Recognizer
 import java.io.File
@@ -23,19 +25,26 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
     private lateinit var model: Model
     private lateinit var audioRecord: AudioRecord
     private var executor: ExecutorService = Executors.newSingleThreadExecutor()
-    private var modelName: String = application.resources.getString(R.string.modelName)
 
     val grammarMapping = loadGrammarMapping()
 
     var wordBuffer: List<SpeechDecoderResult> by mutableStateOf(listOf())
 
-    // Info: w jezyku polskim Vosk niezbyt dobrze odroznia e od i, nie uzywac razem
+    fun getLocalizedContext(): Context {
+
+        val appContext = getApplication<Application>().applicationContext
+        val currentLang = LanguageUtils.getCurrentLanguage(appContext)
+        val localizedContext = LanguageUtils.setLocale(appContext, currentLang)
+
+        return localizedContext
+
+    }
 
     fun loadGrammarMapping(): MutableMap<Char, List<String>> {
 
         val grammar = mutableMapOf<Char, List<String>>()
 
-        val resources = getApplication<Application>().resources
+        val resources = getLocalizedContext().resources
         val letterArrays = resources.obtainTypedArray(R.array.grammar_mapping)
 
         for (i in 0 until letterArrays.length()) {
@@ -124,6 +133,9 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
                 AudioFormat.ENCODING_PCM_16BIT,
                 bufferSize
             )
+
+            var modelName = getLocalizedContext().getString(R.string.modelName)
+            println("updated modelName to $modelName")
 
             var modelDir: File = File(context.filesDir.path + "/models/" + modelName)
 

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -136,7 +136,7 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         recognizer = Recognizer(model, samplerate.toFloat()).apply {
             setWords(true)
             setPartialWords(true)
-            setMaxAlternatives(2)
+         //   setMaxAlternatives(2)
             setGrammar("[\"" + modelGrammar.joinToString(
                 separator = "\",\"",
             ) + "\"]")

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -48,7 +48,6 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         }
 
         letterArrays.recycle()
-        for (el in grammar) println("${el.key}: ${el.value.joinToString(",")}")
         return grammar
 
     }

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -196,19 +196,23 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
 
         val doubtThreshold = 0.7
 
-        for (el in words) {
-            println("${el.word} ${el.confidence}")
-            if (el.confidence < doubtThreshold) {
-                playTone(1000, 200)
-                Handler(Looper.getMainLooper()).postDelayed({
-                }, 100)
-                playTone(1000, 200)
-                return
-            }
-        }
+        if (words.isNotEmpty()) {
 
-        _wordBuffer.postValue(_wordBuffer.value?.plus(words))
-        playTone(280, 500)
+            for (el in words) {
+                println("${el.word} ${el.confidence}")
+                if (el.confidence < doubtThreshold) {
+                    playTone(1000, 200)
+                    Handler(Looper.getMainLooper()).postDelayed({
+                    }, 100)
+                    playTone(1000, 200)
+                    return
+                }
+            }
+
+            _wordBuffer.postValue(_wordBuffer.value?.plus(words))
+            playTone(280, 500)
+
+        }
 
         return
 

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -43,26 +43,27 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
 
     }
 
-    fun loadGrammarMapping(): MutableMap<Char, List<String>> {
+    fun loadGrammarMapping(): MutableMap<String, String> {
 
-        val grammar = mutableMapOf<Char, List<String>>()
+        val grammar = mutableMapOf<String, String>()
+
+        for (i in 'a'..'z') grammar[i.toString()] = i.toString()
+        val sides = listOf("top", "bottom", "left", "right")
+        sides.forEach { it -> grammar[it] = it }
+        val numbers = listOf("one", "two", "three", "four", "five", "six", "seven", "eight", "nine", "zero")
+        numbers.forEach { it -> grammar[it] = it }
 
         val resources = getLocalizedContext().resources
-        val letterArrays = resources.obtainTypedArray(R.array.grammar_mapping)
+        val phoneticWords = resources.getStringArray(R.array.phonetic)
 
-        for (i in 0 until letterArrays.length()) {
-            val arrayId = letterArrays.getResourceId(i, 0)
-            if (arrayId != 0) {
+        for (i in 0 until phoneticWords.size) {
 
-                val words = resources.getStringArray(arrayId).toMutableList()
-                var charCode = 'a' + i
+            var overrideKey = phoneticWords[i].split(':')[0]
+            var overrideValue = phoneticWords[i].split(':')[1]
 
-                if (words.isEmpty()) words.add(charCode.toString())
-                grammar[charCode] = words
+            grammar[overrideKey] = overrideValue
 
-            }
         }
-        letterArrays.recycle()
         return grammar
 
     }
@@ -158,16 +159,11 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
 
     fun initRecognizer(samplerate: Int) {
 
-        val modelGrammar = mutableListOf<String>()
-        for (sublist in grammarMapping.values) {
-            modelGrammar.add(sublist.joinToString("\",\""))
-        }
-
         recognizer = Recognizer(model, samplerate.toFloat()).apply {
             setWords(true)
             setPartialWords(true)
 //            setMaxAlternatives(2)
-            setGrammar("[\"" + modelGrammar.joinToString(
+            setGrammar("[\"" + grammarMapping.values.joinToString(
                 separator = "\",\"",
             ) + "\"]")
         }

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -136,7 +136,7 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         recognizer = Recognizer(model, samplerate.toFloat()).apply {
             setWords(true)
             setPartialWords(true)
-         //   setMaxAlternatives(2)
+            setMaxAlternatives(2)
             setGrammar("[\"" + modelGrammar.joinToString(
                 separator = "\",\"",
             ) + "\"]")

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -29,6 +29,7 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
     private lateinit var model: Model
     private lateinit var audioRecord: AudioRecord
     private var executor: ExecutorService = Executors.newSingleThreadExecutor()
+    private var isOpen: Boolean = false
 
     val grammarMapping = loadGrammarMapping()
 
@@ -108,6 +109,8 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
     fun initialize() {
 
         val context = getApplication<Application>().applicationContext
+
+        isOpen = true
 
         executor.execute {
 
@@ -263,6 +266,10 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun close() {
+
+        if (!isOpen) return
+        isOpen = false
+
         audioRecord.stop()
         audioRecord.release()
         executor.shutdown()

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -4,8 +4,12 @@ import android.annotation.SuppressLint
 import android.app.Application
 import android.content.Context
 import android.media.AudioFormat
+import android.media.AudioManager
 import android.media.AudioRecord
 import android.media.MediaRecorder
+import android.media.ToneGenerator
+import android.os.Handler
+import android.os.Looper
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
@@ -62,18 +66,6 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         return grammar
 
     }
-
-//    @Throws(IOException::class)
-//    fun getNextWord(): SpeechDecoderResult {
-//        if (wordBuffer.isEmpty()) throw IOException("Word buffer is empty")
-//        else {
-//            var word = wordBuffer.last()
-//            wordBuffer = wordBuffer.toMutableList().apply {
-//                removeAt(lastIndex)
-//            }
-//            return word
-//        }
-//    }
 
     @SuppressLint("MissingPermission")
     private fun getMaximumSampleRate(): Int {
@@ -197,6 +189,13 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
                             println(el.word)
                         }
                         _wordBuffer.postValue(_wordBuffer.value?.plus(words))
+
+                        var toneGenerator = ToneGenerator(AudioManager.STREAM_MUSIC, 100)
+                        toneGenerator.startTone(ToneGenerator.TONE_PROP_BEEP, 1000)
+                        Handler(Looper.getMainLooper()).postDelayed({
+                            toneGenerator.release()
+                        }, 1000)
+
                     }
                 }
             }

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -136,7 +136,7 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         recognizer = Recognizer(model, samplerate.toFloat()).apply {
             setWords(true)
             setPartialWords(true)
-            setMaxAlternatives(2)
+           // setMaxAlternatives(2)
             setGrammar("[\"" + modelGrammar.joinToString(
                 separator = "\",\"",
             ) + "\"]")

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -41,12 +41,15 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
         for (i in 0 until letterArrays.length()) {
             val arrayId = letterArrays.getResourceId(i, 0)
             if (arrayId != 0) {
+
                 val words = resources.getStringArray(arrayId).toMutableList()
-                words.add(('a' + i).toString())
-                grammar['a' + i] = words
+                var charCode = 'a' + i
+
+                if (words.isEmpty()) words.add(charCode.toString())
+                grammar[charCode] = words
+
             }
         }
-
         letterArrays.recycle()
         return grammar
 

--- a/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
+++ b/app/src/main/java/me/proteus/myeye/io/ASRViewModel.kt
@@ -218,6 +218,11 @@ class ASRViewModel(application: Application) : AndroidViewModel(application) {
 
     }
 
+    fun clearBuffer() {
+        _wordBuffer.value = emptyList<SpeechDecoderResult>()
+        return
+    }
+
     fun playTone(frequency: Int, duration: Int) {
         val sampleRate = 44100
         val numSamples = duration * sampleRate / 1000

--- a/app/src/main/java/me/proteus/myeye/io/HTTPDownloader.java
+++ b/app/src/main/java/me/proteus/myeye/io/HTTPDownloader.java
@@ -20,6 +20,8 @@ public class HTTPDownloader {
 
     public CompletableFuture<Void> download(String url, File output) {
 
+        System.out.println(url);
+
         CompletableFuture<Void> promise = new CompletableFuture<>();
 
         File path = new File(output.getParent());
@@ -28,7 +30,9 @@ public class HTTPDownloader {
             throw new RuntimeException("Sciezka do katalogu nie istnieje i nie mogla zostac utworzona");
         }
 
-        try (FileOutputStream fos = new FileOutputStream(output)) {
+        try {
+
+            FileOutputStream fos = new FileOutputStream(output);
 
             client.prepareGet(url).execute(new AsyncHandler<Void>() {
                 private long total = 0;
@@ -59,6 +63,9 @@ public class HTTPDownloader {
 
                 @Override
                 public void onThrowable(Throwable t) {
+                    try { fos.close(); } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
                     promise.completeExceptionally(t);
                 }
 

--- a/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
+++ b/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
@@ -60,10 +60,28 @@ public class SpeechDecoderResult {
 
         ArrayList<SpeechDecoderResult> list = new ArrayList<>();
 
+        System.out.println(json);
+
         if (json.has("confidence")) {
 
-            JsonArray resultArray = json.getAsJsonArray("result");
-            for (JsonElement el : resultArray) System.out.println(el);
+            if (json.has("result")) {
+
+                JsonArray resultArray = json.getAsJsonArray("result");
+                float avgConf = json.get("confidence").getAsFloat() / resultArray.size();
+
+                for (JsonElement el : resultArray) {
+
+                    System.out.println(el);
+                    JsonObject obj = el.getAsJsonObject();
+
+                    list.add(new SpeechDecoderResult(
+                            avgConf,
+                            obj.get("start").getAsFloat(),
+                            obj.get("end").getAsFloat(),
+                            obj.get("word").getAsString()
+                    ));
+                }
+            }
 
         } else {
             list.add(new SpeechDecoderResult(

--- a/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
+++ b/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
@@ -25,6 +25,15 @@ public class SpeechDecoderResult {
         ArrayList<SpeechDecoderResult> list = new ArrayList<>();
         JsonObject obj = JsonParser.parseString(json).getAsJsonObject();
 
+        if (obj.has("alternatives")) {
+
+            JsonArray alternatives = obj.getAsJsonArray("alternatives");
+            for (JsonElement el : alternatives) {
+                ArrayList<SpeechDecoderResult> part = getSingleResult(el.getAsJsonObject());
+            }
+
+        }
+
         if (obj.has("result")) {
 
             JsonArray resultArray = obj.getAsJsonArray("result");
@@ -41,6 +50,28 @@ public class SpeechDecoderResult {
                 ));
 
             }
+        }
+
+        return list;
+
+    }
+
+    private static ArrayList<SpeechDecoderResult> getSingleResult(JsonObject json) {
+
+        ArrayList<SpeechDecoderResult> list = new ArrayList<>();
+
+        if (json.has("confidence")) {
+
+            JsonArray resultArray = json.getAsJsonArray("result");
+            for (JsonElement el : resultArray) System.out.println(el);
+
+        } else {
+            list.add(new SpeechDecoderResult(
+                json.get("conf").getAsFloat(),
+                json.get("start").getAsFloat(),
+                json.get("end").getAsFloat(),
+                json.get("word").getAsString()
+            ));
         }
 
         return list;

--- a/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
+++ b/app/src/main/java/me/proteus/myeye/io/SpeechDecoderResult.java
@@ -30,6 +30,7 @@ public class SpeechDecoderResult {
             JsonArray alternatives = obj.getAsJsonArray("alternatives");
             for (JsonElement el : alternatives) {
                 ArrayList<SpeechDecoderResult> part = getSingleResult(el.getAsJsonObject());
+                list.addAll(part);
             }
 
         }
@@ -40,7 +41,6 @@ public class SpeechDecoderResult {
             for (JsonElement el : resultArray) {
 
                 JsonObject result = el.getAsJsonObject();
-                System.out.println(result);
 
                 list.add(new SpeechDecoderResult(
                         result.get("conf").getAsFloat(),
@@ -60,7 +60,7 @@ public class SpeechDecoderResult {
 
         ArrayList<SpeechDecoderResult> list = new ArrayList<>();
 
-        System.out.println(json);
+//        System.out.println("JSON: " + json);
 
         if (json.has("confidence")) {
 
@@ -71,7 +71,6 @@ public class SpeechDecoderResult {
 
                 for (JsonElement el : resultArray) {
 
-                    System.out.println(el);
                     JsonObject obj = el.getAsJsonObject();
 
                     list.add(new SpeechDecoderResult(

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -52,7 +52,7 @@ class SpeechDecoderActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     fun AppContent() {
 
-        val result = viewModel.result
+        val result = viewModel.wordBuffer
 
         Scaffold(
             topBar = {

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.material3.*
 import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -60,33 +61,52 @@ class SpeechDecoderActivity : ComponentActivity() {
             },
             content = { innerPadding ->
 
-                LazyColumn(
+                Box(
                     modifier = Modifier
                         .fillMaxSize()
                         .padding(innerPadding)
                 ) {
-                    itemsIndexed(result) { index, item ->
+                    if (result.isEmpty()) {
 
-                        Box() {
-
-                            val line = "${item.word}"
-                            val probabilityColor = Color(ColorUtils.blendARGB(Color.Red.toArgb(), Color.Green.toArgb(), item.confidence))
-
+                        Box(
+                            modifier = Modifier.fillMaxSize(),
+                            contentAlignment = Alignment.Center
+                        ) {
                             Text(
-                                text = line,
-                                fontSize = 24.sp,
-                                lineHeight = 24.sp,
-                                color = probabilityColor
-                            )
+                                text = "Zacznij mówić",
+                                fontSize = 48.sp,
+                                color = Color.LightGray
 
+                            )
                         }
 
+                    } else {
+                        LazyColumn {
+                            itemsIndexed(result) { index, item ->
+
+                                Box {
+                                    Text(
+                                        text = item.word,
+                                        fontSize = 24.sp,
+                                        lineHeight = 24.sp,
+                                        color = getProbabilityColor(item.confidence)
+                                    )
+
+                                }
+
+                            }
+                        }
                     }
                 }
+
             }
 
         )
 
+    }
+
+    fun getProbabilityColor(p: Float): Color {
+        return Color(ColorUtils.blendARGB(Color.Red.toArgb(), Color.Green.toArgb(), p))
     }
 
 

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -2,6 +2,7 @@ package me.proteus.myeye.ui
 
 import android.Manifest
 import android.app.Activity
+import android.content.Context
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -18,16 +19,18 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
+import me.proteus.myeye.LanguageUtils
 import me.proteus.myeye.MyEyeApplication
 import me.proteus.myeye.io.ASRViewModel
+import me.proteus.myeye.R
 
 class SpeechDecoderActivity : ComponentActivity() {
 
     private val viewModel: ASRViewModel by viewModels()
-
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,6 +56,12 @@ class SpeechDecoderActivity : ComponentActivity() {
         }
     }
 
+    override fun attachBaseContext(newBase: Context?) {
+        val currentLanguage = LanguageUtils.getCurrentLanguage(newBase)
+        val newContext = LanguageUtils.setLocale(newBase, currentLanguage)
+        super.attachBaseContext(newContext)
+    }
+
     @Composable
     @OptIn(ExperimentalMaterial3Api::class)
     fun AppContent() {
@@ -63,7 +72,7 @@ class SpeechDecoderActivity : ComponentActivity() {
         Scaffold(
             topBar = {
                 TopAppBar(
-                    title = { Text("Rozpoznawanie Mowy") },
+                    title = { Text(stringResource(R.string.test)) },
                     actions = {
                         Button(
                             modifier = Modifier
@@ -101,7 +110,7 @@ class SpeechDecoderActivity : ComponentActivity() {
                             contentAlignment = Alignment.Center
                         ) {
                             Text(
-                                text = "Zacznij mówić",
+                                text = stringResource(R.string.start_talking),
                                 fontSize = 48.sp,
                                 color = Color.LightGray
 

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -4,12 +4,7 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
-import android.media.AudioManager
-import android.media.ToneGenerator
 import android.os.Bundle
-import android.os.Handler
-import android.os.Looper
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -4,7 +4,12 @@ import android.Manifest
 import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
+import android.media.AudioManager
+import android.media.ToneGenerator
 import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.result.contract.ActivityResultContracts
@@ -23,10 +28,12 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
+import androidx.lifecycle.LifecycleOwner
 import me.proteus.myeye.LanguageUtils
 import me.proteus.myeye.MyEyeApplication
 import me.proteus.myeye.io.ASRViewModel
 import me.proteus.myeye.R
+import me.proteus.myeye.io.SpeechDecoderResult
 
 class SpeechDecoderActivity : ComponentActivity() {
 
@@ -66,8 +73,15 @@ class SpeechDecoderActivity : ComponentActivity() {
     @OptIn(ExperimentalMaterial3Api::class)
     fun AppContent() {
 
-        val result = viewModel.wordBuffer
+        val result = remember { mutableStateListOf<SpeechDecoderResult>() }
         val context = LocalContext.current
+
+        viewModel.wordBuffer.observe(context as LifecycleOwner) { data ->
+
+            result.clear()
+            result.addAll(data)
+
+        }
 
         Scaffold(
             topBar = {

--- a/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
+++ b/app/src/main/java/me/proteus/myeye/ui/SpeechDecoderActivity.kt
@@ -1,6 +1,7 @@
 package me.proteus.myeye.ui
 
 import android.Manifest
+import android.app.Activity
 import android.content.pm.PackageManager
 import android.os.Bundle
 import androidx.activity.ComponentActivity
@@ -16,8 +17,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.core.graphics.ColorUtils
+import me.proteus.myeye.MyEyeApplication
 import me.proteus.myeye.io.ASRViewModel
 
 class SpeechDecoderActivity : ComponentActivity() {
@@ -54,10 +58,34 @@ class SpeechDecoderActivity : ComponentActivity() {
     fun AppContent() {
 
         val result = viewModel.wordBuffer
+        val context = LocalContext.current
 
         Scaffold(
             topBar = {
-                TopAppBar(title = { Text("Rozpoznawanie Mowy") })
+                TopAppBar(
+                    title = { Text("Rozpoznawanie Mowy") },
+                    actions = {
+                        Button(
+                            modifier = Modifier
+                                .padding(8.dp),
+                            onClick = {
+                                val app = context.applicationContext as MyEyeApplication
+                                val activity = context as Activity
+                                app.setAppLanguage(activity, "pl")
+                            }
+                        ) { Text("Polski") }
+
+                        Button(
+                            modifier = Modifier
+                                .padding(8.dp),
+                            onClick = {
+                                val app = context.applicationContext as MyEyeApplication
+                                val activity = context as Activity
+                                app.setAppLanguage(activity, "en")
+                            }
+                        ) { Text("English") }
+                    }
+                )
             },
             content = { innerPadding ->
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/BuildTest.kt
@@ -25,7 +25,6 @@ class BuildTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
-        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
         TODO("Not yet implemented")

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -30,6 +30,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
+import me.proteus.myeye.GrammarType
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
 import me.proteus.myeye.SerializableStage
@@ -256,7 +257,7 @@ class CircleTest : VisionTest {
             )[ASRViewModel::class]
 
             if (activity.checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-                asr.initialize()
+                asr.initialize(GrammarType.SIDES)
             } else {
                 rpl?.launch(Manifest.permission.RECORD_AUDIO)
             }

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -135,7 +135,6 @@ class CircleTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
-        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
 
@@ -161,7 +160,7 @@ class CircleTest : VisionTest {
                     LetterContainer(
                         directions = stage.first,
                         key = null,
-                        currentStage = difficulty,
+                        currentStage = stage.difficulty,
                         modifier = Modifier
                     )
 
@@ -169,7 +168,7 @@ class CircleTest : VisionTest {
                         LetterContainer(
                             directions = stage.second,
                             key = stage.first,
-                            currentStage = difficulty,
+                            currentStage = stage.difficulty,
                             modifier = Modifier
                         )
                     }

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -286,7 +286,7 @@ class CircleTest : VisionTest {
         while(i++ < 5)  {
             text += directions[abs(random.nextInt() % 4)]
         }
-        println(text)
+
         return text
 
     }
@@ -312,7 +312,7 @@ class CircleTest : VisionTest {
 
     override fun endTest(activity: VisionTestLayoutActivity, isExit: Boolean) {
 
-        super.endTest(activity, true)
+        super.endTest(activity, isExit)
         if (::asr.isInitialized) asr.close()
 
     }

--- a/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/CircleTest.kt
@@ -37,7 +37,6 @@ import me.proteus.myeye.TestResult
 import me.proteus.myeye.VisionTest
 import me.proteus.myeye.io.ASRViewModel
 import me.proteus.myeye.io.ResultDataCollector
-import me.proteus.myeye.io.SpeechDecoderResult
 import me.proteus.myeye.ui.VisionTestLayoutActivity
 import java.util.Random
 import kotlin.math.*
@@ -153,6 +152,8 @@ class CircleTest : VisionTest {
             val mapping = asr.grammarMapping
 
             asr.wordBuffer.observe(context as LifecycleOwner) { data ->
+
+                if (data.isEmpty()) return@observe
 
                 println("Data: ${data.map { it -> it.word }.joinToString(",")}")
 
@@ -311,11 +312,8 @@ class CircleTest : VisionTest {
 
     override fun endTest(activity: VisionTestLayoutActivity, isExit: Boolean) {
 
-        if (!isExit) {
-            super.endTest(activity, true)
-        } else {
-            asr.close()
-        }
+        super.endTest(activity, true)
+        if (::asr.isInitialized) asr.close()
 
     }
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -118,7 +118,6 @@ class ColorArrangementTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
-        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -121,28 +121,30 @@ class ColorArrangementTest : VisionTest {
         onUpdate: (String) -> Unit
     ) {
 
-        val inputColors by remember(stage) {
+        if (stage.first.isNotEmpty())  println("First ${stage.first.split(' ').map { getHue(it) }}")
+        if (stage.second.isNotEmpty()) println("Second ${stage.second.split(' ').map { getHue(it) }}")
+
+        val questionColors by remember(stage) {
             derivedStateOf {
                 if (isResult) stage.second.split(' ')
                 else stage.first.split(' ')
             }
         }
 
-        val sortedColors by remember(stage) {
+        val answerColors by remember(stage) {
             derivedStateOf {
-                if (isResult) stage.first.split(' ')
-                else inputColors.sortedBy { getHue(it) }
+                questionColors.sortedBy { getHue(it) }
             }
         }
 
-        var stageColors by remember { mutableStateOf(inputColors) }
+        var stageColors by remember { mutableStateOf(questionColors) }
 
         var correctnessMap by remember { mutableStateOf<Map<Int, Int>>(emptyMap()) }
 
-        LaunchedEffect(inputColors) {
-            stageColors = inputColors
+        LaunchedEffect(questionColors) {
+            stageColors = questionColors
             if (isResult) {
-                correctnessMap = getCorrectnessMapping(sortedColors, stageColors)
+                correctnessMap = getCorrectnessMapping(answerColors, stageColors)
             }
 
         }
@@ -267,7 +269,7 @@ class ColorArrangementTest : VisionTest {
                             horizontalAlignment = Alignment.CenterHorizontally,
                             verticalArrangement = Arrangement.SpaceEvenly
                         ) {
-                            itemsIndexed(sortedColors) { index, item ->
+                            itemsIndexed(answerColors) { index, item ->
 
                                 FarnsworthItem(Modifier, item, index, currentlyDragged)
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ColorArrangementTest.kt
@@ -2,6 +2,7 @@ package me.proteus.myeye.visiontests
 
 import android.graphics.Color.parseColor
 import android.graphics.Color.colorToHSV
+import androidx.activity.result.ActivityResultLauncher
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.gestures.Orientation
@@ -321,7 +322,8 @@ class ColorArrangementTest : VisionTest {
     override fun BeginTest(
         activity: VisionTestLayoutActivity,
         isResult: Boolean,
-        result: TestResult?
+        result: TestResult?,
+        rpl: ActivityResultLauncher<String>?
     ) {
         colors = activity.resources.getStringArray(R.array.farnsworth_colors)
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/ExampleTest.kt
@@ -42,7 +42,6 @@ class ExampleTest : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
-        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
 

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -14,9 +14,9 @@ import androidx.compose.material.icons.twotone.Face
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.getValue
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -134,7 +134,6 @@ class SnellenChart : VisionTest {
         activity: VisionTestLayoutActivity,
         stage: SerializableStage,
         isResult: Boolean,
-        difficulty: Int,
         onUpdate: (String) -> Unit
     ) {
 
@@ -156,14 +155,14 @@ class SnellenChart : VisionTest {
                     horizontalArrangement = Arrangement.SpaceEvenly
                 ) {
                     LetterContainer(
-                        stage = difficulty,
+                        stage = stage.difficulty,
                         text = stage.first,
                         key = null,
                         modifier = Modifier
                     )
                     if (isResult) {
                         LetterContainer(
-                            stage = difficulty,
+                            stage = stage.difficulty,
                             text = stage.second,
                             key = stage.first,
                             modifier = Modifier

--- a/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
+++ b/app/src/main/java/me/proteus/myeye/visiontests/SnellenChart.kt
@@ -29,6 +29,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ViewModelProvider
+import me.proteus.myeye.GrammarType
 import me.proteus.myeye.R
 import me.proteus.myeye.ScreenScalingUtils.getScreenInfo
 import me.proteus.myeye.SerializableStage
@@ -240,7 +241,7 @@ class SnellenChart : VisionTest {
             )[ASRViewModel::class]
 
             if (activity.checkSelfPermission(Manifest.permission.RECORD_AUDIO) == PackageManager.PERMISSION_GRANTED) {
-                asr.initialize()
+                asr.initialize(GrammarType.LETTERS_LOGMAR)
             } else {
                 rpl?.launch(Manifest.permission.RECORD_AUDIO)
             }
@@ -278,19 +279,19 @@ class SnellenChart : VisionTest {
 
     }
 
-    fun randomChar(): Char {
+    fun randomText(n: Int): String {
+
+        var all = GrammarType.LETTERS_LOGMAR.items.shuffled()
 
         var random = Random()
-        return ((abs(random.nextInt() % 25)) + 65).toChar()
-    }
-
-    fun randomText(n: Int): String {
 
         var text: String = ""
         var i: Int = 0
+        var j: Int = random.nextInt(all.size)
 
         while(i++ < n)  {
-            text += randomChar()
+            text += all[j]
+            j++; j %= all.size
         }
 
         return text

--- a/app/src/main/res/values-pl/grammar.xml
+++ b/app/src/main/res/values-pl/grammar.xml
@@ -3,67 +3,33 @@
 
     <string name="modelName"> "vosk-model-small-pl-0.22" </string>
 
-    <string-array name="a" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="b" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="c" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="d" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="e" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="f" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="g" tools:ignore="InconsistentArrays">
-        <item> gdzie </item>
-    </string-array>
-    <string-array name="h" tools:ignore="InconsistentArrays">
-        <item> ha </item>
-    </string-array>
-    <string-array name="i" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="j" tools:ignore="InconsistentArrays">
-        <item> jod </item>
-    </string-array>
-    <string-array name="k" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="l" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="m" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="n" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="o" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="p" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="q" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="r" tools:ignore="InconsistentArrays">
-        <item> er </item>
-    </string-array>
-    <string-array name="s" tools:ignore="InconsistentArrays">
-        <item> es </item>
-    </string-array>
-    <string-array name="t" tools:ignore="InconsistentArrays">
-        <item> te </item>
-    </string-array>
-    <string-array name="u" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="v" tools:ignore="InconsistentArrays">
-        <item> wał </item>
-    </string-array>
-    <string-array name="w" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="x" tools:ignore="InconsistentArrays">
-        <item> ix </item>
-    </string-array>
-    <string-array name="y" tools:ignore="InconsistentArrays">
-        <item> igrek </item>
-    </string-array>
-    <string-array name="z" tools:ignore="InconsistentArrays">
-        <item> zet </item>
+    <string-array name="phonetic" tools:ignore="InconsistentArrays">
+
+        <item>g:gdzie</item>
+        <item>h:ha</item>
+        <item>j:jod</item>
+        <item>r:er</item>
+        <item>s:es</item>
+        <item>t:te</item>
+        <item>v:wał</item>
+        <item>x:ix</item>
+        <item>y:igrek</item>
+        <item>z:zet</item>
+        <item>top:góra</item>
+        <item>bottom:dół</item>
+        <item>left:lewa</item>
+        <item>right:prawa</item>
+        <item>one:jeden</item>
+        <item>two:dwa</item>
+        <item>three:trzy</item>
+        <item>four:cztery</item>
+        <item>five:pięć</item>
+        <item>six:sześć</item>
+        <item>seven:siedem</item>
+        <item>eight:osiem</item>
+        <item>nine:dziewięć</item>
+        <item>zero:zero</item>
+
     </string-array>
 
 </resources>

--- a/app/src/main/res/values-pl/grammar.xml
+++ b/app/src/main/res/values-pl/grammar.xml
@@ -6,13 +6,10 @@
     <string-array name="a" tools:ignore="InconsistentArrays">
     </string-array>
     <string-array name="b" tools:ignore="InconsistentArrays">
-        <item> be </item>
     </string-array>
     <string-array name="c" tools:ignore="InconsistentArrays">
-        <item> ce </item>
     </string-array>
     <string-array name="d" tools:ignore="InconsistentArrays">
-        <item> de </item>
     </string-array>
     <string-array name="e" tools:ignore="InconsistentArrays">
     </string-array>
@@ -30,16 +27,12 @@
         <item> jod </item>
     </string-array>
     <string-array name="k" tools:ignore="InconsistentArrays">
-        <item> ka </item>
     </string-array>
     <string-array name="l" tools:ignore="InconsistentArrays">
-        <item> el </item>
     </string-array>
     <string-array name="m" tools:ignore="InconsistentArrays">
-        <item> em </item>
     </string-array>
     <string-array name="n" tools:ignore="InconsistentArrays">
-        <item> en </item>
     </string-array>
     <string-array name="o" tools:ignore="InconsistentArrays">
     </string-array>
@@ -62,7 +55,6 @@
         <item> wał </item>
     </string-array>
     <string-array name="w" tools:ignore="InconsistentArrays">
-        <item> wu </item>
     </string-array>
     <string-array name="x" tools:ignore="InconsistentArrays">
         <item> ix </item>

--- a/app/src/main/res/values-pl/grammar.xml
+++ b/app/src/main/res/values-pl/grammar.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <string name="modelName"> "vosk-model-small-pl-0.22" </string>
+
+    <string-array name="a" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="b" tools:ignore="InconsistentArrays">
+        <item> be </item>
+    </string-array>
+    <string-array name="c" tools:ignore="InconsistentArrays">
+        <item> ce </item>
+    </string-array>
+    <string-array name="d" tools:ignore="InconsistentArrays">
+        <item> de </item>
+    </string-array>
+    <string-array name="e" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="f" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="g" tools:ignore="InconsistentArrays">
+        <item> gdzie </item>
+    </string-array>
+    <string-array name="h" tools:ignore="InconsistentArrays">
+        <item> ha </item>
+    </string-array>
+    <string-array name="i" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="j" tools:ignore="InconsistentArrays">
+        <item> jod </item>
+    </string-array>
+    <string-array name="k" tools:ignore="InconsistentArrays">
+        <item> ka </item>
+    </string-array>
+    <string-array name="l" tools:ignore="InconsistentArrays">
+        <item> el </item>
+    </string-array>
+    <string-array name="m" tools:ignore="InconsistentArrays">
+        <item> em </item>
+    </string-array>
+    <string-array name="n" tools:ignore="InconsistentArrays">
+        <item> en </item>
+    </string-array>
+    <string-array name="o" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="p" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="q" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="r" tools:ignore="InconsistentArrays">
+        <item> er </item>
+    </string-array>
+    <string-array name="s" tools:ignore="InconsistentArrays">
+        <item> es </item>
+    </string-array>
+    <string-array name="t" tools:ignore="InconsistentArrays">
+        <item> te </item>
+    </string-array>
+    <string-array name="u" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="v" tools:ignore="InconsistentArrays">
+        <item> wał </item>
+    </string-array>
+    <string-array name="w" tools:ignore="InconsistentArrays">
+        <item> wu </item>
+    </string-array>
+    <string-array name="x" tools:ignore="InconsistentArrays">
+        <item> ix </item>
+    </string-array>
+    <string-array name="y" tools:ignore="InconsistentArrays">
+        <item> igrek </item>
+    </string-array>
+    <string-array name="z" tools:ignore="InconsistentArrays">
+        <item> zet </item>
+    </string-array>
+
+</resources>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="test">Rozpoznawanie Mowy</string>
+    <string name="start_talking">Zacznij mówić</string>
+</resources>

--- a/app/src/main/res/values/grammar.xml
+++ b/app/src/main/res/values/grammar.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources xmlns:tools="http://schemas.android.com/tools">
+
+    <string name="modelName"> "vosk-model-small-en-us-0.15" </string>
+
+    <string-array name="a" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="b" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="c" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="d" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="e" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="f" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="g" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="h" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="i" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="j" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="k" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="l" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="m" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="n" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="o" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="p" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="q" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="r" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="s" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="t" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="u" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="v" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="w" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="x" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="y" tools:ignore="InconsistentArrays">
+    </string-array>
+    <string-array name="z" tools:ignore="InconsistentArrays">
+    </string-array>
+
+    <string-array name="grammar_mapping" translatable="false">
+        <item>@array/a</item>
+        <item>@array/b</item>
+        <item>@array/c</item>
+        <item>@array/d</item>
+        <item>@array/e</item>
+        <item>@array/f</item>
+        <item>@array/g</item>
+        <item>@array/h</item>
+        <item>@array/i</item>
+        <item>@array/j</item>
+        <item>@array/k</item>
+        <item>@array/l</item>
+        <item>@array/m</item>
+        <item>@array/n</item>
+        <item>@array/o</item>
+        <item>@array/p</item>
+        <item>@array/q</item>
+        <item>@array/r</item>
+        <item>@array/s</item>
+        <item>@array/t</item>
+        <item>@array/u</item>
+        <item>@array/v</item>
+        <item>@array/w</item>
+        <item>@array/x</item>
+        <item>@array/y</item>
+        <item>@array/z</item>
+    </string-array>
+
+</resources>

--- a/app/src/main/res/values/grammar.xml
+++ b/app/src/main/res/values/grammar.xml
@@ -3,86 +3,8 @@
 
     <string name="modelName"> "vosk-model-small-en-us-0.15" </string>
 
-    <string-array name="a" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="b" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="c" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="d" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="e" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="f" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="g" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="h" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="i" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="j" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="k" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="l" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="m" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="n" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="o" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="p" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="q" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="r" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="s" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="t" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="u" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="v" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="w" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="x" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="y" tools:ignore="InconsistentArrays">
-    </string-array>
-    <string-array name="z" tools:ignore="InconsistentArrays">
-    </string-array>
+    <string-array name="phonetic" tools:ignore="InconsistentArrays">
 
-    <string-array name="grammar_mapping" translatable="false">
-        <item>@array/a</item>
-        <item>@array/b</item>
-        <item>@array/c</item>
-        <item>@array/d</item>
-        <item>@array/e</item>
-        <item>@array/f</item>
-        <item>@array/g</item>
-        <item>@array/h</item>
-        <item>@array/i</item>
-        <item>@array/j</item>
-        <item>@array/k</item>
-        <item>@array/l</item>
-        <item>@array/m</item>
-        <item>@array/n</item>
-        <item>@array/o</item>
-        <item>@array/p</item>
-        <item>@array/q</item>
-        <item>@array/r</item>
-        <item>@array/s</item>
-        <item>@array/t</item>
-        <item>@array/u</item>
-        <item>@array/v</item>
-        <item>@array/w</item>
-        <item>@array/x</item>
-        <item>@array/y</item>
-        <item>@array/z</item>
     </string-array>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
-    <string name="app_name">MyEye</string>
+    <string name="app_name" translatable="false">MyEye</string>
+    <string name="test">Speech Recognition</string>
+    <string name="start_talking">Speak now</string>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.7.2"
+agp = "8.7.3"
 kotlin = "2.0.0"
 coreKtx = "1.13.1"
 junit = "4.13.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ appcompat = "1.7.0"
 gson = "2.11.0"
 asyncHttpClient = "3.0.0"
 zip4j = "2.11.5"
+slf4jSimple = "2.1.0-alpha1"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -40,6 +41,7 @@ androidx-appcompat = { group = "androidx.appcompat", name = "appcompat", version
 gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
 async-http-client = { group = "org.asynchttpclient", name = "async-http-client", version.ref = "asyncHttpClient" }
 zip4j = { group = "net.lingala.zip4j", name = "zip4j", version.ref = "zip4j" }
+slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4jSimple" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
Po krótkiej przerwie powrót do prac nad implementacją `ASRViewModel` w testach wzroku - oto najważniejsze związane z tym procesem nowości:
 - Naprawiono błąd w `HTTPDownloader`, zamykający w niektórych przypadkach od razu strumień danych pliku ZIP modelu ASR (= uniemożliwiający pobranie go),
 - Usunięto niepotrzebny parametr `difficulty` z `VisionTest.DisplayStage`,
 - Rozwinięto system Vosk ASR przez dodanie zasobów fonetycznych dla każdego języka i utworzenie systemu LiveData do obserwacji bufora rozpoznanych słów i użyto w testach LogMAR i Landolt C (w innych nie jest on potrzebny),
 - Po rozpoznaniu tekstu odtwarzany jest teraz dźwięk - wyższy oznacza konieczność powtórzenia, niższy potwierdza przejście dalej,
 - Dodano nowy enum `GrammarType` - pozwala wybrać zestaw liter/słów odpowiednich do testu aby zawęzić zakres do rozpoznawania,
 - Nowa klasa aplikacji `MyEyeApplication` i klasa pomocnicza `LanguageUtils` odpowiedzialne za zmianę języka użytkownika - teksty lokalizowane są umieszczane w odpowiednich zasobach.

**To Do:**
 - Dodanie panelu ustawień, w którym użytkownik może zmienić język (na razie jest to możliwe tylko w `SpeechDecoderActivity`),
 - Ulepszenia UI (menu, nawigacja itd.),
 - Wykorzystanie czujników ruchu i położenia do kalibracji testów wzroku wymagających informacji o odległości (póki co jest zahardkodowana i wynosi ok. 1 metr).